### PR TITLE
[Feat/10] 카카오 소셜 로그인/회원가입 API 구현

### DIFF
--- a/src/main/java/com/challenge/api/controller/AuthController.java
+++ b/src/main/java/com/challenge/api/controller/AuthController.java
@@ -6,7 +6,6 @@ import com.challenge.api.dto.AuthResponse;
 import com.challenge.api.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +21,7 @@ public class AuthController {
 
     @PostMapping("/kakao")
     public ApiResponse<AuthResponse.authDto> kakaoAuth(@RequestBody AuthRequest.kakaoRequest request) {
-        return ApiResponse.of(HttpStatus.OK, authService.kakaoAuth(request.getAccessToken()));
+        return ApiResponse.ok(authService.kakaoAuth(request.getAccessToken()));
     }
 
 }

--- a/src/main/java/com/challenge/api/controller/AuthController.java
+++ b/src/main/java/com/challenge/api/controller/AuthController.java
@@ -20,9 +20,9 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @PostMapping("/login/kakao")
-    public ApiResponse<AuthResponse.loginDto> kakaoLogin(@RequestBody AuthRequest.kakaoLoginRequest request) {
-        return ApiResponse.of(HttpStatus.OK, authService.kakaoLogin(request.getAccessToken()));
+    @PostMapping("/kakao")
+    public ApiResponse<AuthResponse.authDto> kakaoAuth(@RequestBody AuthRequest.kakaoRequest request) {
+        return ApiResponse.of(HttpStatus.OK, authService.kakaoAuth(request.getAccessToken()));
     }
 
 }

--- a/src/main/java/com/challenge/api/dto/AuthRequest.java
+++ b/src/main/java/com/challenge/api/dto/AuthRequest.java
@@ -7,7 +7,7 @@ public class AuthRequest {
 
     @Getter
     @NoArgsConstructor
-    public static class kakaoLoginRequest {
+    public static class kakaoRequest {
 
         String accessToken;
 

--- a/src/main/java/com/challenge/api/dto/AuthResponse.java
+++ b/src/main/java/com/challenge/api/dto/AuthResponse.java
@@ -11,7 +11,7 @@ public class AuthResponse {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class loginDto {
+    public static class authDto {
 
         Long memberId;
         String accessToken;

--- a/src/main/java/com/challenge/api/dto/AuthResponse.java
+++ b/src/main/java/com/challenge/api/dto/AuthResponse.java
@@ -15,6 +15,7 @@ public class AuthResponse {
 
         Long memberId;
         String accessToken;
+        String refreshToken;
         Long accessTokenExpiresIn;
 
     }

--- a/src/main/java/com/challenge/api/service/AuthService.java
+++ b/src/main/java/com/challenge/api/service/AuthService.java
@@ -4,13 +4,13 @@ import com.challenge.api.dto.AuthResponse;
 import com.challenge.domain.member.LoginType;
 import com.challenge.domain.member.Member;
 import com.challenge.domain.member.MemberRepository;
-import com.challenge.exception.ErrorCode;
-import com.challenge.exception.GlobalException;
 import com.challenge.utils.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -23,23 +23,64 @@ public class AuthService {
     private final JwtUtil jwtUtil;
 
     /**
-     * kakao access token을 이용해 사용자 정보 조회 및 jwt access token 발급
+     * 카카오 소셜 회원가입 및 로그인 메소드
+     * kakao access token을 이용해 사용자 정보 조회 및 등록 후 jwt access token 발급
      *
      * @param kakaoAccessToken
      * @return
      */
     @Transactional
-    public AuthResponse.loginDto kakaoLogin(String kakaoAccessToken) {
+    public AuthResponse.authDto kakaoAuth(String kakaoAccessToken) {
         // 카카오 서버로부터 사용자 정보 가져오기
         AuthResponse.kakaoResultDto userInfo = kakaoApiService.getUserInfo(kakaoAccessToken);
 
-        // socialId와 socialType에 해당하는 회원 존재하는지 검증
-        Member member = memberRepository.findBySocialIdAndLoginType(userInfo.getSocialId(), LoginType.KAKAO)
-                .orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
+        // socialId와 socialType에 해당하는 회원 존재 여부 확인
+        Optional<Member> memberOptional = memberRepository.findBySocialIdAndLoginType(userInfo.getSocialId(),
+                LoginType.KAKAO);
 
+        if (memberOptional.isPresent()) { // 회원 존재하는 경우 로그인 처리
+            return login(memberOptional.get());
+        } else { // 회원 존재하지 않는 경우 회원가입 처리
+            return kakaoRegister(userInfo);
+        }
+    }
+
+    /**
+     * 회원 로그인 메소드
+     *
+     * @param member
+     * @return
+     */
+    private AuthResponse.authDto login(Member member) {
         String accessToken = jwtUtil.createAccessToken(member.getId());
 
-        return AuthResponse.loginDto.builder()
+        return AuthResponse.authDto.builder()
+                .memberId(member.getId())
+                .accessToken(accessToken)
+                .accessTokenExpiresIn(jwtUtil.getTokenExpirationTime(accessToken))
+                .build();
+    }
+
+    /**
+     * 카카오 회원 등록 메소드
+     *
+     * @param userInfo
+     * @return
+     */
+    private AuthResponse.authDto kakaoRegister(AuthResponse.kakaoResultDto userInfo) {
+        // 회원 엔티티 생성 및 저장
+        Member member = Member.builder()
+                .socialId(userInfo.getSocialId())
+                .email(userInfo.getEmail())
+                .loginType(LoginType.KAKAO)
+                .build();
+
+        memberRepository.save(member);
+
+        // 토큰 발급
+        String accessToken = jwtUtil.createAccessToken(member.getId());
+
+        return AuthResponse.authDto.builder()
                 .memberId(member.getId())
                 .accessToken(accessToken)
                 .accessTokenExpiresIn(jwtUtil.getTokenExpirationTime(accessToken))

--- a/src/main/java/com/challenge/api/service/AuthService.java
+++ b/src/main/java/com/challenge/api/service/AuthService.java
@@ -53,10 +53,12 @@ public class AuthService {
      */
     private AuthResponse.authDto login(Member member) {
         String accessToken = jwtUtil.createAccessToken(member.getId());
+        String refreshToken = jwtUtil.createRefreshToken(member.getId());
 
         return AuthResponse.authDto.builder()
                 .memberId(member.getId())
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .accessTokenExpiresIn(jwtUtil.getTokenExpirationTime(accessToken))
                 .build();
     }
@@ -79,10 +81,12 @@ public class AuthService {
 
         // 토큰 발급
         String accessToken = jwtUtil.createAccessToken(member.getId());
+        String refreshToken = jwtUtil.createRefreshToken(member.getId());
 
         return AuthResponse.authDto.builder()
                 .memberId(member.getId())
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .accessTokenExpiresIn(jwtUtil.getTokenExpirationTime(accessToken))
                 .build();
     }

--- a/src/main/java/com/challenge/api/service/KakaoApiService.java
+++ b/src/main/java/com/challenge/api/service/KakaoApiService.java
@@ -33,6 +33,8 @@ public class KakaoApiService {
 
     private static final String ACCESS_TOKEN_REQUEST_URL = "https://kauth.kakao.com/oauth/token";
     private static final String USER_INFO_REQUEST_URL = "https://kapi.kakao.com/v2/user/me";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
 
     /**
      * 인증 code를 가지고 카카오 API 서버로부터 access token을 받아오는 메소드
@@ -87,7 +89,7 @@ public class KakaoApiService {
     public AuthResponse.kakaoResultDto getUserInfo(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        headers.set("Authorization", "Bearer " + accessToken);
+        headers.set(AUTHORIZATION_HEADER, "Bearer " + accessToken);
 
         HttpEntity<?> entity = new HttpEntity<>(headers);
 
@@ -107,7 +109,7 @@ public class KakaoApiService {
 
                 return AuthResponse.kakaoResultDto.builder().socialId(id).email(email).build();
             }
-            
+
             log.error("Failed to get user info. Status code: {}", response.getStatusCode());
             throw new GlobalException(ErrorCode.KAKAO_REQ_FAILED);
         } catch (Exception e) {

--- a/src/main/java/com/challenge/domain/BaseDateTimeEntity.java
+++ b/src/main/java/com/challenge/domain/BaseDateTimeEntity.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @Getter
-public class BaseDateTimeEntity {
+public abstract class BaseDateTimeEntity {
 
     @CreatedDate
     @Column(updatable = false)

--- a/src/main/java/com/challenge/domain/member/Gender.java
+++ b/src/main/java/com/challenge/domain/member/Gender.java
@@ -1,0 +1,5 @@
+package com.challenge.domain.member;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/challenge/domain/member/Job.java
+++ b/src/main/java/com/challenge/domain/member/Job.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum Job {
-
     MGMT("경영·비즈니스"),           // Management
     DEV("개발"),                    // Development
     PLNO("기획·운영"),              // Planning & Operations
@@ -29,6 +28,4 @@ public enum Job {
     GOV_WEL_ENV("공공·복지·환경");   // Government, Welfare & Environment
 
     private final String description;
-
 }
-

--- a/src/main/java/com/challenge/domain/member/Job.java
+++ b/src/main/java/com/challenge/domain/member/Job.java
@@ -1,0 +1,34 @@
+package com.challenge.domain.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Job {
+
+    MGMT("경영·비즈니스"),           // Management
+    DEV("개발"),                    // Development
+    PLNO("기획·운영"),              // Planning & Operations
+    DATA_AI("데이터·AI·ML"),        // Data, AI, Machine Learning
+    DESIGN("디자인"),               // Design
+    MKT_ADS("마케팅·광고"),         // Marketing & Ads
+    FIN_CONS("금융·컨설팅"),         // Finance & Consulting
+    MEDIA("미디어"),                // Media
+    ECOM_RETAIL("이커머스·리테일"), // E-commerce & Retail
+    HR_LABOR("인사·채용·노무"),      // Human Resources & Labor
+    SALES("고객·영업"),             // Sales & Customer Support
+    RND("연구·R&D"),                // Research & Development
+    ENG("엔지니어링"),              // Engineering
+    ACC_FIN("회계·재무"),           // Accounting & Finance
+    PROD_QUAL("생산·품질"),         // Production & Quality
+    GAME_DEV("게임 기획·개발"),      // Game Planning & Development
+    LOG_PURCH("물류·구매"),         // Logistics & Procurement
+    EDU("교육"),                    // Education
+    MED_BIO("의료·제약·바이오"),     // Medical, Pharmaceutical & Bio
+    GOV_WEL_ENV("공공·복지·환경");   // Government, Welfare & Environment
+
+    private final String description;
+
+}
+

--- a/src/main/java/com/challenge/domain/member/Member.java
+++ b/src/main/java/com/challenge/domain/member/Member.java
@@ -14,11 +14,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Entity
 @Table(name = "member")
+@DynamicInsert
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,34 +39,34 @@ public class Member extends BaseDateTimeEntity {
     @Column(name = "email", nullable = false, length = 100)
     private String email;
 
-    @Column(name = "nickname", nullable = false, length = 30)
+    @Column(name = "nickname", length = 30)
     private String nickname;
 
     @Column(name = "birth")
     private Date birth;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(10)", nullable = false)
+    @Column(columnDefinition = "VARCHAR(10)")
     private Gender gender;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(20)", nullable = false)
+    @Column(columnDefinition = "VARCHAR(20)")
     private Job job;
 
     @Column(name = "profile_img", length = 1000)
     private String profileImg;
 
-    @Column(name = "is_notification_received", nullable = false)
+    @Column(name = "is_notification_received", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
     private Boolean isNotificationReceived;
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     private LoginType loginType;
 
-    @Column(name = "is_deleted", columnDefinition = "boolean default false")
+    @Column(name = "is_deleted", columnDefinition = "BOOLEAN DEFAULT false")
     private Boolean isDeleted;
 
-    @Column(name = "deleted_at", length = 13)
-    private String deletedAt;
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
 }

--- a/src/main/java/com/challenge/domain/member/Member.java
+++ b/src/main/java/com/challenge/domain/member/Member.java
@@ -1,8 +1,19 @@
 package com.challenge.domain.member;
 
 import com.challenge.domain.BaseDateTimeEntity;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.Date;
 
@@ -31,8 +42,13 @@ public class Member extends BaseDateTimeEntity {
     @Column(name = "birth")
     private Date birth;
 
-    @Column(name = "gender", length = 10)
-    private String gender;
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)", nullable = false)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(20)", nullable = false)
+    private Job job;
 
     @Column(name = "profile_img", length = 1000)
     private String profileImg;

--- a/src/main/java/com/challenge/utils/JwtUtil.java
+++ b/src/main/java/com/challenge/utils/JwtUtil.java
@@ -153,5 +153,4 @@ public class JwtUtil {
         }
     }
 
-
 }

--- a/src/main/java/com/challenge/utils/JwtUtil.java
+++ b/src/main/java/com/challenge/utils/JwtUtil.java
@@ -24,6 +24,9 @@ public class JwtUtil {
     private final Key key;
     private final long accessTokenExpTime;
 
+    @Value("${jwt.refresh_expiration_day}")
+    private long refreshExpireDay;
+
     private static final String AUTHORIZATION_HEADER = "Authorization";
 
     public JwtUtil(
@@ -41,42 +44,37 @@ public class JwtUtil {
      * @return
      */
     public String createAccessToken(Long memberId) {
-        Claims claims = Jwts.claims();
-        claims.put("memberId", memberId);
-
-        long now = (new Date()).getTime();
-        Date validity = new Date(now + this.accessTokenExpTime);
-
-        return Jwts.builder()
-                .setClaims(claims)
-                .setIssuedAt(new Date(now))
-                .setExpiration(validity)
-                .signWith(key, SignatureAlgorithm.HS256)
-                .compact();
+        return createToken(memberId, accessTokenExpTime);
     }
 
     /**
-     * JWT Claims 추출 메소드
+     * refresh token 생성 메소드
      *
-     * @param accessToken
-     * @return JWT Claims
+     * @param memberId
+     * @return
      */
-    public Claims parseClaims(String accessToken) {
-        try {
-            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
-        } catch (ExpiredJwtException e) {
-            return e.getClaims();
-        }
+    public String createRefreshToken(Long memberId) {
+        return createToken(memberId, refreshExpireDay);
     }
 
     /**
-     * token 만료 시간 추출 메소드
+     * token claim에서 만료 시간 추출 메소드
      *
      * @param token
      * @return
      */
-    public long getTokenExpirationTime(String token) {
+    public Long getTokenExpirationTime(String token) {
         return parseClaims(token).getExpiration().getTime();
+    }
+
+    /**
+     * token claim에서 memberId 추출 메소드
+     *
+     * @param token
+     * @return
+     */
+    public Long getMemberId(String token) {
+        return parseClaims(token).get("memberId", Long.class);
     }
 
     /**
@@ -120,13 +118,40 @@ public class JwtUtil {
     }
 
     /**
-     * token claim에서 memberId 추출 메소드
+     * token 생성 메소드
      *
-     * @param token
+     * @param memberId
+     * @param expireTime
      * @return
      */
-    public Long getMemberId(String token) {
-        return parseClaims(token).get("memberId", Long.class);
+    private String createToken(Long memberId, Long expireTime) {
+        Claims claims = Jwts.claims();
+        claims.put("memberId", memberId);
+
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + expireTime);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(now))
+                .setExpiration(validity)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
     }
+
+    /**
+     * JWT Claims 추출 메소드
+     *
+     * @param accessToken
+     * @return JWT Claims
+     */
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,7 @@ social:
 jwt:
   secret: ${JWT_SECRET}
   access_expiration_time: 36000000 # 10시간 (10 * 60 * 60 * 1000 밀리초)
+  refresh_expiration_day: 14 # 2주
 
 ---
 # 로컬 환경


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
카카오 소셜 로그인/회원가입 API 구현
로그인/회원가입 API 응답으로 refresh token도 포함

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 카카오 소셜 로그인/회원가입을 통합해 하나의 auth API로 구현
- 로그인/회원가입 API 응답으로 refresh token도 포함
- member 엔티티에 job 필드 추가

## ⏳ 작업 내용
- [x] 카카오 Auth (로그인+회원가입) API 구현
- [x] refresh token 발급 추가 
- [x] member 엔티티 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
로그인, 회원가입 API를 하나로 통합해서 만들고, 서베이 등록은 별도의 API로 받는 것으로 생각해서 로그인/회원가입 통합 auth API로 구현했습니다..!
