### PR TITLE
[Feat/27] JWT 검증 인터셉터 및 커스텀 어노테이션 구현

### DIFF
--- a/src/main/java/com/challenge/annotation/AuthMember.java
+++ b/src/main/java/com/challenge/annotation/AuthMember.java
@@ -1,0 +1,12 @@
+package com.challenge.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthMember {
+
+}

--- a/src/main/java/com/challenge/annotation/resolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/challenge/annotation/resolver/AuthMemberArgumentResolver.java
@@ -1,0 +1,47 @@
+package com.challenge.annotation.resolver;
+
+import com.challenge.annotation.AuthMember;
+import com.challenge.domain.member.Member;
+import com.challenge.domain.member.MemberRepository;
+import com.challenge.exception.ErrorCode;
+import com.challenge.exception.GlobalException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // @AuthMember 어노테이션이 붙어 있는지 여부
+        boolean hasParameterAnnotation = parameter.hasParameterAnnotation(AuthMember.class);
+
+        // 파라미터 타입이 Member 클래스인지 여부
+        boolean hasMemberClass = Member.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasParameterAnnotation && hasMemberClass;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        Long memberId = (Long) request.getAttribute("memberId");
+        if (memberId == null) {
+            throw new GlobalException(ErrorCode.MEMBER_EXTRACTION_FAILED);
+        }
+
+        return memberRepository.findById(memberId).orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/challenge/api/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/challenge/api/interceptor/AuthInterceptor.java
@@ -1,0 +1,63 @@
+package com.challenge.api.interceptor;
+
+import com.challenge.api.ApiResponse;
+import com.challenge.exception.GlobalException;
+import com.challenge.utils.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+                             Object handler) throws Exception {
+        try {
+            // request에서 access token 추출
+            String accessToken = jwtUtil.resolveToken(request);
+
+            // access token 값 검증
+            jwtUtil.validateToken(accessToken);
+
+            // access token에서 memberId 추출
+            Long memberId = jwtUtil.getMemberId(accessToken);
+
+            // request 객체에 값 저장
+            request.setAttribute("memberId", memberId);
+        } catch (GlobalException exception) {
+            sendErrorResponse(response, exception, request.getRequestURI());
+            return false;
+        }
+
+        return true;
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, GlobalException exception,
+                                   String requestUrl) throws IOException {
+        // 응답 Content-Type 설정
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(exception.getStatus().value());
+
+        // 에러 응답 생성
+        ApiResponse<Object> errorResponse = ApiResponse.builder()
+                .status(exception.getStatus())
+                .code(exception.getCode())
+                .message(exception.getMessage())
+                .url(requestUrl)
+                .build();
+
+        // JSON 직렬화 및 응답 작성
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+
+}

--- a/src/main/java/com/challenge/config/WebConfig.java
+++ b/src/main/java/com/challenge/config/WebConfig.java
@@ -1,8 +1,10 @@
 package com.challenge.config;
 
+import com.challenge.annotation.resolver.AuthMemberArgumentResolver;
 import com.challenge.api.interceptor.AuthInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -13,14 +15,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
+    private final AuthMemberArgumentResolver authMemberArgumentResolver;
     private final AuthInterceptor authInterceptor;
     private final List<String> excludeEndpoints = Arrays.asList("/api/v1/auth/**");
 
+    // 인터셉터 설정
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authInterceptor)
                 .addPathPatterns("/api/**") // 인터셉터 적용할 endpoint
                 .excludePathPatterns(excludeEndpoints); // 인터셉터 적용하지 않을 endpoint
+    }
+
+    // authMember 어노테이션 resolver 설정
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authMemberArgumentResolver);
     }
 
 }

--- a/src/main/java/com/challenge/config/WebConfig.java
+++ b/src/main/java/com/challenge/config/WebConfig.java
@@ -1,0 +1,26 @@
+package com.challenge.config;
+
+import com.challenge.api.interceptor.AuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+    private final List<String> excludeEndpoints = Arrays.asList("/api/v1/auth/**");
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/api/**") // 인터셉터 적용할 endpoint
+                .excludePathPatterns(excludeEndpoints); // 인터셉터 적용하지 않을 endpoint
+    }
+
+}

--- a/src/main/java/com/challenge/exception/ErrorCode.java
+++ b/src/main/java/com/challenge/exception/ErrorCode.java
@@ -37,7 +37,8 @@ public enum ErrorCode {
     INVALID_CLAIMS(UNAUTHORIZED, "AUTH_4007", "JWT의 클레임이 유효하지 않습니다."),
     INVALID_REFRESH_TOKEN(BAD_REQUEST, "AUTH_4008", "리프레쉬 토큰이 유효하지 않습니다. 다시 로그인 해주세요"),
     UNAUTHORIZED_EXCEPTION(UNAUTHORIZED, "AUTH_4009", "로그인 후 이용가능합니다. 토큰을 입력해 주세요"),
-    INACTIVE_MEMBER(NOT_FOUND, "AUTH_4010", "탈퇴한 사용자 입니다."),
+    MEMBER_EXTRACTION_FAILED(NOT_FOUND, "AUTH_4010", "회원 정보를 추출할 수 없습니다."),
+    INACTIVE_MEMBER(NOT_FOUND, "AUTH_4011", "탈퇴한 사용자 입니다."),
 
     /**
      * 소셜 로그인 관련 에러

--- a/src/main/java/com/challenge/exception/ErrorCode.java
+++ b/src/main/java/com/challenge/exception/ErrorCode.java
@@ -28,13 +28,16 @@ public enum ErrorCode {
     /**
      * 인증 관련 에러
      */
-    INVALID_REQUEST_BODY(BAD_REQUEST, "AUTH_4000", "잘못된 요청입니다."),
-    EXPIRED_KAKAO_ACCESS_TOKEN(UNAUTHORIZED, "AUTH_4001", "유효하지 않은 액세스 토큰입니다."),
-    INVALID_TOKEN_EXCEPTION(UNAUTHORIZED, "AUTH_4002", "토큰이 올바르지 않습니다."),
-    INVALID_REFRESH_TOKEN(BAD_REQUEST, "AUTH_4003", "리프레쉬 토큰이 유효하지 않습니다. 다시 로그인 해주세요"),
-    EXPIRED_JWT_EXCEPTION(UNAUTHORIZED, "AUTH_4004", "기존 토큰이 만료되었습니다. 토큰을 재발급해주세요."),
-    UNAUTHORIZED_EXCEPTION(UNAUTHORIZED, "AUTH_4005", "로그인 후 이용가능합니다. 토큰을 입력해 주세요"),
-    INACTIVE_MEMBER(NOT_FOUND, "AUTH_4006", "탈퇴한 사용자 입니다."),
+    MISSING_AUTH_HEADER(UNAUTHORIZED, "AUTH_4001", "Authorization 헤더가 없습니다."),
+    INVALID_AUTH_HEADER(UNAUTHORIZED, "AUTH_4002", "Authorization 헤더가 올바르지 않습니다."),
+    INVALID_SIGNATURE(UNAUTHORIZED, "AUTH_4003", "JWT 서명이 유효하지 않습니다."),
+    MALFORMED_TOKEN(UNAUTHORIZED, "AUTH_4004", "JWT의 형식이 올바르지 않습니다."),
+    UNSUPPORTED_TOKEN(UNAUTHORIZED, "AUTH_4005", "지원되지 않는 JWT입니다."),
+    EXPIRED_JWT_EXCEPTION(UNAUTHORIZED, "AUTH_4006", "기존 토큰이 만료되었습니다. 토큰을 재발급해주세요."),
+    INVALID_CLAIMS(UNAUTHORIZED, "AUTH_4007", "JWT의 클레임이 유효하지 않습니다."),
+    INVALID_REFRESH_TOKEN(BAD_REQUEST, "AUTH_4008", "리프레쉬 토큰이 유효하지 않습니다. 다시 로그인 해주세요"),
+    UNAUTHORIZED_EXCEPTION(UNAUTHORIZED, "AUTH_4009", "로그인 후 이용가능합니다. 토큰을 입력해 주세요"),
+    INACTIVE_MEMBER(NOT_FOUND, "AUTH_4010", "탈퇴한 사용자 입니다."),
 
     /**
      * 소셜 로그인 관련 에러


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
JWT 검증 인터셉터 및 커스텀 어노테이션 구현

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- jwt 검증 및 memberId 추출을 위한 AuthInterceptor 구현
- ErrorCode의 인증 관련 에러 enum 추가
- JwtUtil 코드 리팩토링
- @AuthMember 커스텀 어노테이션 및 ArgumentResolver 구현

## ⏳ 작업 내용
- [x] AuthInterceptor 구현
- [x] JwtUtil 코드 리팩토링
- [x] @AuthMember 커스텀 어노테이션 및 ArgumentResolver 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
요청 보낸 회원의 Member 엔티티가 필요한 경우 컨트롤러에서 @AuthMember 어노테이션을 사용하면 됩니다.
```
    @GetMapping("/member/test")
    public ApiResponse<String> test(@AuthMember Member member) {
        return ApiResponse.ok(member.getNickname());
    }
```

AuthInterceptor는 /api 아래 경로에 대해 실행되도록 했습니다..! (/api/v1/auth 이후 경로는 제외)
