### PR TITLE
[Test/29] 카카오 로그인/회원가입 API 테스트코드 작성

### DIFF
--- a/src/main/java/com/challenge/api/controller/auth/request/KakaoLoginRequest.java
+++ b/src/main/java/com/challenge/api/controller/auth/request/KakaoLoginRequest.java
@@ -2,14 +2,16 @@ package com.challenge.api.controller.auth.request;
 
 import com.challenge.api.service.auth.request.KakaoLoginServiceRequest;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class KakaoLoginRequest {
 
-    @NotBlank
+    @NotBlank(message = "access token은 필수 입력값입니다.")
     private String accessToken;
 
     public KakaoLoginServiceRequest toServiceRequest() {

--- a/src/main/java/com/challenge/api/controller/auth/request/KakaoLoginRequest.java
+++ b/src/main/java/com/challenge/api/controller/auth/request/KakaoLoginRequest.java
@@ -2,13 +2,12 @@ package com.challenge.api.controller.auth.request;
 
 import com.challenge.api.service.auth.request.KakaoLoginServiceRequest;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class KakaoLoginRequest {
 
     @NotBlank(message = "access token은 필수 입력값입니다.")
@@ -18,6 +17,11 @@ public class KakaoLoginRequest {
         return KakaoLoginServiceRequest.builder()
                 .accessToken(accessToken)
                 .build();
+    }
+
+    @Builder
+    private KakaoLoginRequest(String accessToken) {
+        this.accessToken = accessToken;
     }
 
 }

--- a/src/main/java/com/challenge/api/controller/auth/request/KakaoSigninRequest.java
+++ b/src/main/java/com/challenge/api/controller/auth/request/KakaoSigninRequest.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,30 +16,30 @@ import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class KakaoSigninRequest {
 
-    @NotBlank
+    @NotBlank(message = "access token은 필수 입력값입니다.")
     private String accessToken;
 
-    @NotBlank
     @Pattern(regexp = "^[가-힣a-zA-Z0-9]{4,10}$", message = "닉네임은 4~10자이며, 띄어쓰기와 특수문자를 사용할 수 없습니다.")
     private String nickname;
 
-    @NotNull
-    @Past
+    @NotNull(message = "birth는 필수 입력값입니다.")
+    @Past(message = "birth는 과거 날짜여야 합니다.")
     private LocalDate birth;
 
-    @NotNull
+    @NotNull(message = "gender는 필수 입력값입니다.")
     private Gender gender;
 
-    @NotNull
-    @Min(1)
-    @Max(20)
+    @NotNull(message = "jobId는 필수 입력값입니다.")
+    @Min(value = 1, message = "jobId는 1 이상의 값이어야 합니다.")
+    @Max(value = 20, message = "jobId는 20 이하의 값이어야 합니다.")
     private Long jobId;
 
-    @NotNull
-    @Min(1)
-    @Max(4)
+    @NotNull(message = "yearId는 필수 입력값입니다.")
+    @Min(value = 1, message = "yearId는 1 이상의 값이어야 합니다.")
+    @Max(value = 4, message = "yearId는 4 이하의 값이어야 합니다.")
     private int yearId;
 
     public KakaoSigninServiceRequest toServiceRequest() {

--- a/src/main/java/com/challenge/api/controller/auth/request/KakaoSigninRequest.java
+++ b/src/main/java/com/challenge/api/controller/auth/request/KakaoSigninRequest.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Pattern;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,7 +16,6 @@ import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class KakaoSigninRequest {
 
     @NotBlank(message = "access token은 필수 입력값입니다.")
@@ -51,6 +50,17 @@ public class KakaoSigninRequest {
                 .jobId(jobId)
                 .yearId(yearId)
                 .build();
+    }
+
+    @Builder
+    private KakaoSigninRequest(String accessToken, String nickname, LocalDate birth, Gender gender, Long jobId,
+            int yearId) {
+        this.accessToken = accessToken;
+        this.nickname = nickname;
+        this.birth = birth;
+        this.gender = gender;
+        this.jobId = jobId;
+        this.yearId = yearId;
     }
 
 }

--- a/src/main/java/com/challenge/api/service/auth/AuthService.java
+++ b/src/main/java/com/challenge/api/service/auth/AuthService.java
@@ -7,10 +7,10 @@ import com.challenge.api.service.auth.response.SocialInfoResponse;
 import com.challenge.api.validator.auth.AuthValidator;
 import com.challenge.domain.job.Job;
 import com.challenge.domain.job.JobRepository;
+import com.challenge.domain.member.JobYear;
 import com.challenge.domain.member.LoginType;
 import com.challenge.domain.member.Member;
 import com.challenge.domain.member.MemberRepository;
-import com.challenge.domain.member.Year;
 import com.challenge.exception.ErrorCode;
 import com.challenge.exception.GlobalException;
 import com.challenge.utils.JwtUtil;
@@ -75,11 +75,11 @@ public class AuthService {
                 .orElseThrow(() -> new GlobalException(ErrorCode.JOB_NOT_FOUND));
 
         // 연차 enum 데이터 설정
-        Year year = Year.of(request.getYearId());
+        JobYear jobYear = JobYear.of(request.getYearId());
 
         // member 엔티티 생성 및 저장
         Member member = Member.create(userInfo.getSocialId(), userInfo.getEmail(), request.getNickname(),
-                request.getBirth(), request.getGender(), year, LoginType.KAKAO, job);
+                request.getBirth(), request.getGender(), jobYear, LoginType.KAKAO, job);
         Member savedMember = memberRepository.save(member);
 
         // 토큰 발급

--- a/src/main/java/com/challenge/domain/job/Job.java
+++ b/src/main/java/com/challenge/domain/job/Job.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,5 +25,11 @@ public class Job {
 
     @Column(nullable = false, length = 100)
     private String description;
+
+    @Builder
+    private Job(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
 
 }

--- a/src/main/java/com/challenge/domain/member/JobYear.java
+++ b/src/main/java/com/challenge/domain/member/JobYear.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @Getter
-public enum Year {
+public enum JobYear {
 
     LT_1Y(1),
     Y1_2(2),
@@ -17,10 +17,10 @@ public enum Year {
     private final int id;
 
     // id로 Year 객체 조회하기 위한 map
-    private static final Map<Integer, Year> YEAR_MAP = Arrays.stream(values())
-            .collect(Collectors.toUnmodifiableMap(Year::getId, year -> year));
+    private static final Map<Integer, JobYear> YEAR_MAP = Arrays.stream(values())
+            .collect(Collectors.toUnmodifiableMap(JobYear::getId, jobYear -> jobYear));
 
-    Year(int id) {
+    JobYear(int id) {
         this.id = id;
     }
 
@@ -30,12 +30,12 @@ public enum Year {
      * @param id
      * @return
      */
-    public static Year of(int id) {
-        Year year = YEAR_MAP.get(id);
-        if (year == null) {
+    public static JobYear of(int id) {
+        JobYear jobYear = YEAR_MAP.get(id);
+        if (jobYear == null) {
             throw new IllegalArgumentException("Invalid id: " + id);
         }
-        return year;
+        return jobYear;
     }
 
 }

--- a/src/main/java/com/challenge/domain/member/Member.java
+++ b/src/main/java/com/challenge/domain/member/Member.java
@@ -54,7 +54,7 @@ public class Member extends BaseDateTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
-    private Year year;
+    private JobYear jobYear;
 
     @Column(length = 1000)
     private String profileImg;
@@ -82,29 +82,29 @@ public class Member extends BaseDateTimeEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Notification> notifications = new ArrayList<>();
 
-    public static Member create(Long socialId, String email, String nickname, LocalDate birth, Gender gender, Year year,
-                                LoginType loginType, Job job) {
+    public static Member create(Long socialId, String email, String nickname, LocalDate birth, Gender gender,
+            JobYear jobYear, LoginType loginType, Job job) {
         return Member.builder()
                 .socialId(socialId)
                 .email(email)
                 .nickname(nickname)
                 .birth(birth)
                 .gender(gender)
-                .year(year)
+                .jobYear(jobYear)
                 .loginType(loginType)
                 .job(job)
                 .build();
     }
 
-    @Builder(access = AccessLevel.PROTECTED)
-    private Member(Long socialId, String email, String nickname, LocalDate birth, Gender gender, Year year,
-                   LoginType loginType, Job job) {
+    @Builder
+    private Member(Long socialId, String email, String nickname, LocalDate birth, Gender gender, JobYear jobYear,
+            LoginType loginType, Job job) {
         this.socialId = socialId;
         this.email = email;
         this.nickname = nickname;
         this.birth = birth;
         this.gender = gender;
-        this.year = year;
+        this.jobYear = jobYear;
         this.loginType = loginType;
         this.job = job;
     }

--- a/src/test/java/com/challenge/api/controller/ControllerTestSupport.java
+++ b/src/test/java/com/challenge/api/controller/ControllerTestSupport.java
@@ -1,0 +1,61 @@
+package com.challenge.api.controller;
+
+import com.challenge.annotation.resolver.AuthMemberArgumentResolver;
+import com.challenge.api.interceptor.AuthInterceptor;
+import com.challenge.domain.member.Gender;
+import com.challenge.domain.member.JobYear;
+import com.challenge.domain.member.LoginType;
+import com.challenge.domain.member.Member;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ActiveProfiles("test")
+@WebMvcTest
+public class ControllerTestSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @MockBean
+    protected AuthInterceptor authInterceptor;
+
+    @MockBean
+    protected AuthMemberArgumentResolver authMemberArgumentResolver;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    protected static final Long MOCK_SOCIAL_ID = 1L;
+    protected static final String MOCK_EMAIL = "test@naver.com";
+    protected static final String MOCK_NICKNAME = "test";
+    protected static final LocalDate MOCK_BIRTH = LocalDate.of(2000, 1, 1);
+
+    @BeforeEach
+    public void baseSetUp() throws Exception {
+        // 인터셉터가 항상 true를 반환하도록 Mock 설정
+        given(authInterceptor.preHandle(any(), any(), any())).willReturn(true);
+
+        // 리졸버가 mockMember를 반환하도록 Mock 설정
+        Member mockMember = Member.builder()
+                .socialId(MOCK_SOCIAL_ID)
+                .email(MOCK_EMAIL)
+                .loginType(LoginType.KAKAO)
+                .nickname(MOCK_NICKNAME)
+                .birth(MOCK_BIRTH)
+                .gender(Gender.MALE)
+                .jobYear(JobYear.LT_1Y)
+                .build();
+        given(authMemberArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(mockMember);
+    }
+
+}

--- a/src/test/java/com/challenge/api/controller/auth/AuthControllerTest.java
+++ b/src/test/java/com/challenge/api/controller/auth/AuthControllerTest.java
@@ -30,7 +30,7 @@ public class AuthControllerTest extends ControllerTestSupport {
 
     private static final String MOCK_KAKAO_ACCESS_TOKEN = "test-kakao-access-token";
     private static final String MOCK_ACCESS_TOKEN = "test-access-token";
-    public static final String MOCK_REFRESH_TOKEN = "test-refresh-token";
+    private static final String MOCK_REFRESH_TOKEN = "test-refresh-token";
 
     private LoginResponse mockLoginResponse;
 
@@ -53,7 +53,9 @@ public class AuthControllerTest extends ControllerTestSupport {
         @Test
         void kakaoLoginSucceeds() throws Exception {
             // given
-            KakaoLoginRequest request = new KakaoLoginRequest(MOCK_KAKAO_ACCESS_TOKEN);
+            KakaoLoginRequest request = KakaoLoginRequest.builder()
+                    .accessToken(MOCK_ACCESS_TOKEN)
+                    .build();
 
             // when // then
             mockMvc.perform(post("/api/v1/auth/login/kakao")
@@ -71,7 +73,9 @@ public class AuthControllerTest extends ControllerTestSupport {
         @Test
         void kakaoLoginFailedWhenAccessTokenIsBlank() throws Exception {
             // given
-            KakaoLoginRequest request = new KakaoLoginRequest(" ");
+            KakaoLoginRequest request = KakaoLoginRequest.builder()
+                    .accessToken(" ")
+                    .build();
 
             // when //then
             mockMvc.perform(post("/api/v1/auth/login/kakao")
@@ -104,8 +108,14 @@ public class AuthControllerTest extends ControllerTestSupport {
         @Test
         void kakaoSigninSucceeds() throws Exception {
             // given
-            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_KAKAO_ACCESS_TOKEN, MOCK_NICKNAME, MOCK_BIRTH,
-                    Gender.FEMALE, 1L, 1);
+            KakaoSigninRequest request = KakaoSigninRequest.builder()
+                    .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                    .nickname(MOCK_NICKNAME)
+                    .birth(MOCK_BIRTH)
+                    .gender(Gender.FEMALE)
+                    .jobId(1L)
+                    .yearId(1)
+                    .build();
 
             // when // then
             mockMvc.perform(post("/api/v1/auth/signin/kakao")
@@ -124,8 +134,14 @@ public class AuthControllerTest extends ControllerTestSupport {
         @Test
         void kakaoSigninFailedWhenAccessTokenIsBlank() throws Exception {
             // given
-            KakaoSigninRequest request = new KakaoSigninRequest(" ", MOCK_NICKNAME, MOCK_BIRTH,
-                    Gender.FEMALE, 1L, 1);
+            KakaoSigninRequest request = KakaoSigninRequest.builder()
+                    .accessToken(" ")
+                    .nickname(MOCK_NICKNAME)
+                    .birth(MOCK_BIRTH)
+                    .gender(Gender.FEMALE)
+                    .jobId(1L)
+                    .yearId(1)
+                    .build();
 
             // when //then
             mockMvc.perform(post("/api/v1/auth/signin/kakao")
@@ -141,8 +157,14 @@ public class AuthControllerTest extends ControllerTestSupport {
         @Test
         void kakaoSigninFailedWhenNicknameIsBlank() throws Exception {
             // given
-            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, " ", MOCK_BIRTH,
-                    Gender.FEMALE, 1L, 1);
+            KakaoSigninRequest request = KakaoSigninRequest.builder()
+                    .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                    .nickname(" ")
+                    .birth(MOCK_BIRTH)
+                    .gender(Gender.FEMALE)
+                    .jobId(1L)
+                    .yearId(1)
+                    .build();
 
             // when // then
             mockMvc.perform(post("/api/v1/auth/signin/kakao")
@@ -158,8 +180,14 @@ public class AuthControllerTest extends ControllerTestSupport {
         @Test
         void kakaoSigninFailedWhenNicknameIsInvalid() throws Exception {
             // given
-            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, "abcdefg!!@12", MOCK_BIRTH,
-                    Gender.FEMALE, 1L, 1);
+            KakaoSigninRequest request = KakaoSigninRequest.builder()
+                    .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                    .nickname("abcdefg!!@12")
+                    .birth(MOCK_BIRTH)
+                    .gender(Gender.FEMALE)
+                    .jobId(1L)
+                    .yearId(1)
+                    .build();
 
             // when // then
             mockMvc.perform(post("/api/v1/auth/signin/kakao")
@@ -175,8 +203,14 @@ public class AuthControllerTest extends ControllerTestSupport {
         @Test
         void kakaoSigninFailedWhenBirthIsNull() throws Exception {
             // given
-            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, null,
-                    Gender.FEMALE, 1L, 1);
+            KakaoSigninRequest request = KakaoSigninRequest.builder()
+                    .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                    .nickname(MOCK_NICKNAME)
+                    .birth(null)
+                    .gender(Gender.FEMALE)
+                    .jobId(1L)
+                    .yearId(1)
+                    .build();
 
             // when // then
             mockMvc.perform(post("/api/v1/auth/signin/kakao")
@@ -192,8 +226,14 @@ public class AuthControllerTest extends ControllerTestSupport {
         @Test
         void kakaoSigninFailedWhenBirthIsNotPast() throws Exception {
             // given
-            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, LocalDate.now(),
-                    Gender.FEMALE, 1L, 1);
+            KakaoSigninRequest request = KakaoSigninRequest.builder()
+                    .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                    .nickname(MOCK_NICKNAME)
+                    .birth(LocalDate.now())
+                    .gender(Gender.FEMALE)
+                    .jobId(1L)
+                    .yearId(1)
+                    .build();
 
             // when // then
             mockMvc.perform(post("/api/v1/auth/signin/kakao")
@@ -209,8 +249,14 @@ public class AuthControllerTest extends ControllerTestSupport {
         @Test
         void kakaoSigninFailedWhenGenderIsNull() throws Exception {
             // given
-            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, MOCK_BIRTH,
-                    null, 1L, 1);
+            KakaoSigninRequest request = KakaoSigninRequest.builder()
+                    .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                    .nickname(MOCK_NICKNAME)
+                    .birth(MOCK_BIRTH)
+                    .gender(null)
+                    .jobId(1L)
+                    .yearId(1)
+                    .build();
 
             // when // then
             mockMvc.perform(post("/api/v1/auth/signin/kakao")
@@ -226,8 +272,14 @@ public class AuthControllerTest extends ControllerTestSupport {
         @Test
         void kakaoSigninFailedWhenJobIdIsNull() throws Exception {
             // given
-            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, MOCK_BIRTH,
-                    Gender.FEMALE, null, 1);
+            KakaoSigninRequest request = KakaoSigninRequest.builder()
+                    .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                    .nickname(MOCK_NICKNAME)
+                    .birth(MOCK_BIRTH)
+                    .gender(Gender.FEMALE)
+                    .jobId(null)
+                    .yearId(1)
+                    .build();
 
             // when // then
             mockMvc.perform(post("/api/v1/auth/signin/kakao")
@@ -243,8 +295,14 @@ public class AuthControllerTest extends ControllerTestSupport {
         @Test
         void kakaoSigninFailedWhenJobIdIsLessThanMin() throws Exception {
             // given
-            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, MOCK_BIRTH,
-                    Gender.FEMALE, 0L, 1);
+            KakaoSigninRequest request = KakaoSigninRequest.builder()
+                    .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                    .nickname(MOCK_NICKNAME)
+                    .birth(MOCK_BIRTH)
+                    .gender(Gender.FEMALE)
+                    .jobId(0L)
+                    .yearId(1)
+                    .build();
 
             // when // then
             mockMvc.perform(post("/api/v1/auth/signin/kakao")
@@ -260,8 +318,14 @@ public class AuthControllerTest extends ControllerTestSupport {
         @Test
         void kakaoSigninFailedWhenJobIdIsMoreThanMax() throws Exception {
             // given
-            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, MOCK_BIRTH,
-                    Gender.FEMALE, 21L, 1);
+            KakaoSigninRequest request = KakaoSigninRequest.builder()
+                    .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                    .nickname(MOCK_NICKNAME)
+                    .birth(MOCK_BIRTH)
+                    .gender(Gender.FEMALE)
+                    .jobId(21L)
+                    .yearId(1)
+                    .build();
 
             // when // then
             mockMvc.perform(post("/api/v1/auth/signin/kakao")
@@ -277,8 +341,14 @@ public class AuthControllerTest extends ControllerTestSupport {
         @Test
         void kakaoSigninFailedWhenYearIdIsLessThanMin() throws Exception {
             // given
-            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, MOCK_BIRTH,
-                    Gender.FEMALE, 1L, 0);
+            KakaoSigninRequest request = KakaoSigninRequest.builder()
+                    .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                    .nickname(MOCK_NICKNAME)
+                    .birth(MOCK_BIRTH)
+                    .gender(Gender.FEMALE)
+                    .jobId(1L)
+                    .yearId(0)
+                    .build();
 
             // when // then
             mockMvc.perform(post("/api/v1/auth/signin/kakao")
@@ -294,8 +364,14 @@ public class AuthControllerTest extends ControllerTestSupport {
         @Test
         void kakaoSigninFailedWhenYearIdIsMoreThanMax() throws Exception {
             // given
-            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, MOCK_BIRTH,
-                    Gender.FEMALE, 1L, 5);
+            KakaoSigninRequest request = KakaoSigninRequest.builder()
+                    .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                    .nickname(MOCK_NICKNAME)
+                    .birth(MOCK_BIRTH)
+                    .gender(Gender.FEMALE)
+                    .jobId(1L)
+                    .yearId(5)
+                    .build();
 
             // when // then
             mockMvc.perform(post("/api/v1/auth/signin/kakao")

--- a/src/test/java/com/challenge/api/controller/auth/AuthControllerTest.java
+++ b/src/test/java/com/challenge/api/controller/auth/AuthControllerTest.java
@@ -1,0 +1,312 @@
+package com.challenge.api.controller.auth;
+
+import com.challenge.api.controller.ControllerTestSupport;
+import com.challenge.api.controller.auth.request.KakaoLoginRequest;
+import com.challenge.api.controller.auth.request.KakaoSigninRequest;
+import com.challenge.api.service.auth.AuthService;
+import com.challenge.api.service.auth.response.LoginResponse;
+import com.challenge.domain.member.Gender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+public class AuthControllerTest extends ControllerTestSupport {
+
+    @MockBean
+    private AuthService authService;
+
+    private static final String MOCK_KAKAO_ACCESS_TOKEN = "test-kakao-access-token";
+    private static final String MOCK_ACCESS_TOKEN = "test-access-token";
+    public static final String MOCK_REFRESH_TOKEN = "test-refresh-token";
+
+    private LoginResponse mockLoginResponse;
+
+    @Nested
+    @DisplayName("카카오 로그인")
+    class KakaoLoginTests {
+
+        @BeforeEach
+        void setUp() {
+            // 서비스 mock 처리
+            mockLoginResponse = LoginResponse.builder()
+                    .memberId(1L)
+                    .accessToken(MOCK_ACCESS_TOKEN)
+                    .refreshToken(MOCK_REFRESH_TOKEN)
+                    .build();
+            given(authService.kakaoLogin(any())).willReturn(mockLoginResponse);
+        }
+
+        @DisplayName("카카오 로그인 성공")
+        @Test
+        void kakaoLoginSucceeds() throws Exception {
+            // given
+            KakaoLoginRequest request = new KakaoLoginRequest(MOCK_KAKAO_ACCESS_TOKEN);
+
+            // when // then
+            mockMvc.perform(post("/api/v1/auth/login/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("OK"))
+                    .andExpect(jsonPath("$.code").isEmpty())
+                    .andExpect(jsonPath("$.url").isEmpty())
+                    .andExpect(jsonPath("$.data.accessToken").value(MOCK_ACCESS_TOKEN))
+                    .andExpect(jsonPath("$.data.refreshToken").value(MOCK_REFRESH_TOKEN));
+        }
+
+        @DisplayName("카카오 로그인 실패: access token이 공백인 경우 에러 응답을 반환한다.")
+        @Test
+        void kakaoLoginFailedWhenAccessTokenIsBlank() throws Exception {
+            // given
+            KakaoLoginRequest request = new KakaoLoginRequest(" ");
+
+            // when //then
+            mockMvc.perform(post("/api/v1/auth/login/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is(400))
+                    .andExpect(jsonPath("$.message").value("access token은 필수 입력값입니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.url").value("/api/v1/auth/login/kakao"));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("카카오 회원가입")
+    class KakaoSigninTests {
+
+        @BeforeEach
+        void setUp() {
+            // 서비스 mock 처리
+            mockLoginResponse = LoginResponse.builder()
+                    .memberId(1L)
+                    .accessToken(MOCK_ACCESS_TOKEN)
+                    .refreshToken(MOCK_REFRESH_TOKEN)
+                    .build();
+            given(authService.kakaoSignin(any())).willReturn(mockLoginResponse);
+        }
+
+        @DisplayName("카카오 회원가입 성공")
+        @Test
+        void kakaoSigninSucceeds() throws Exception {
+            // given
+            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_KAKAO_ACCESS_TOKEN, MOCK_NICKNAME, MOCK_BIRTH,
+                    Gender.FEMALE, 1L, 1);
+
+            // when // then
+            mockMvc.perform(post("/api/v1/auth/signin/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("OK"))
+                    .andExpect(jsonPath("$.code").isEmpty())
+                    .andExpect(jsonPath("$.url").isEmpty())
+                    .andExpect(jsonPath("$.data.memberId").value(1L))
+                    .andExpect(jsonPath("$.data.accessToken").value(MOCK_ACCESS_TOKEN))
+                    .andExpect(jsonPath("$.data.refreshToken").value(MOCK_REFRESH_TOKEN));
+        }
+
+        @DisplayName("카카오 회원가입 실패: access token이 공백인 경우 에러 응답을 반환한다.")
+        @Test
+        void kakaoSigninFailedWhenAccessTokenIsBlank() throws Exception {
+            // given
+            KakaoSigninRequest request = new KakaoSigninRequest(" ", MOCK_NICKNAME, MOCK_BIRTH,
+                    Gender.FEMALE, 1L, 1);
+
+            // when //then
+            mockMvc.perform(post("/api/v1/auth/signin/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is(400))
+                    .andExpect(jsonPath("$.message").value("access token은 필수 입력값입니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
+        }
+
+        @DisplayName("카카오 회원가입 실패: nickname이 공백인 경우 에러 응답을 반환한다.")
+        @Test
+        void kakaoSigninFailedWhenNicknameIsBlank() throws Exception {
+            // given
+            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, " ", MOCK_BIRTH,
+                    Gender.FEMALE, 1L, 1);
+
+            // when // then
+            mockMvc.perform(post("/api/v1/auth/signin/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is(400))
+                    .andExpect(jsonPath("$.message").value("닉네임은 4~10자이며, 띄어쓰기와 특수문자를 사용할 수 없습니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
+        }
+
+        @DisplayName("카카오 회원가입 실패: nickname이 길이/문자 조건을 위반한 경우 에러 응답을 반환한다.")
+        @Test
+        void kakaoSigninFailedWhenNicknameIsInvalid() throws Exception {
+            // given
+            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, "abcdefg!!@12", MOCK_BIRTH,
+                    Gender.FEMALE, 1L, 1);
+
+            // when // then
+            mockMvc.perform(post("/api/v1/auth/signin/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is(400))
+                    .andExpect(jsonPath("$.message").value("닉네임은 4~10자이며, 띄어쓰기와 특수문자를 사용할 수 없습니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
+        }
+
+        @DisplayName("카카오 회원가입 실패: birth가 null인 경우 에러 응답을 반환한다.")
+        @Test
+        void kakaoSigninFailedWhenBirthIsNull() throws Exception {
+            // given
+            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, null,
+                    Gender.FEMALE, 1L, 1);
+
+            // when // then
+            mockMvc.perform(post("/api/v1/auth/signin/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is(400))
+                    .andExpect(jsonPath("$.message").value("birth는 필수 입력값입니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
+        }
+
+        @DisplayName("카카오 회원가입 실패: birth가 과거 날짜가 아닌 경우 에러 응답을 반환한다.")
+        @Test
+        void kakaoSigninFailedWhenBirthIsNotPast() throws Exception {
+            // given
+            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, LocalDate.now(),
+                    Gender.FEMALE, 1L, 1);
+
+            // when // then
+            mockMvc.perform(post("/api/v1/auth/signin/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is(400))
+                    .andExpect(jsonPath("$.message").value("birth는 과거 날짜여야 합니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
+        }
+
+        @DisplayName("카카오 회원가입 실패: gender가 null인 경우 에러 응답을 반환한다.")
+        @Test
+        void kakaoSigninFailedWhenGenderIsNull() throws Exception {
+            // given
+            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, MOCK_BIRTH,
+                    null, 1L, 1);
+
+            // when // then
+            mockMvc.perform(post("/api/v1/auth/signin/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is(400))
+                    .andExpect(jsonPath("$.message").value("gender는 필수 입력값입니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
+        }
+
+        @DisplayName("카카오 회원가입 실패: jobId가 null인 경우 에러 응답을 반환한다.")
+        @Test
+        void kakaoSigninFailedWhenJobIdIsNull() throws Exception {
+            // given
+            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, MOCK_BIRTH,
+                    Gender.FEMALE, null, 1);
+
+            // when // then
+            mockMvc.perform(post("/api/v1/auth/signin/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is(400))
+                    .andExpect(jsonPath("$.message").value("jobId는 필수 입력값입니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
+        }
+
+        @DisplayName("카카오 회원가입 실패: jobId가 1 미만인 경우 에러 응답을 반환한다.")
+        @Test
+        void kakaoSigninFailedWhenJobIdIsLessThanMin() throws Exception {
+            // given
+            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, MOCK_BIRTH,
+                    Gender.FEMALE, 0L, 1);
+
+            // when // then
+            mockMvc.perform(post("/api/v1/auth/signin/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is(400))
+                    .andExpect(jsonPath("$.message").value("jobId는 1 이상의 값이어야 합니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
+        }
+
+        @DisplayName("카카오 회원가입 실패: jobId가 20 초과인 경우 에러 응답을 반환한다.")
+        @Test
+        void kakaoSigninFailedWhenJobIdIsMoreThanMax() throws Exception {
+            // given
+            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, MOCK_BIRTH,
+                    Gender.FEMALE, 21L, 1);
+
+            // when // then
+            mockMvc.perform(post("/api/v1/auth/signin/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is(400))
+                    .andExpect(jsonPath("$.message").value("jobId는 20 이하의 값이어야 합니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
+        }
+
+        @DisplayName("카카오 회원가입 실패: yearId가 1 미만인 경우 에러 응답을 반환한다.")
+        @Test
+        void kakaoSigninFailedWhenYearIdIsLessThanMin() throws Exception {
+            // given
+            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, MOCK_BIRTH,
+                    Gender.FEMALE, 1L, 0);
+
+            // when // then
+            mockMvc.perform(post("/api/v1/auth/signin/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is(400))
+                    .andExpect(jsonPath("$.message").value("yearId는 1 이상의 값이어야 합니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
+        }
+
+        @DisplayName("카카오 회원가입 실패: yearId가 4 초과인 경우 에러 응답을 반환한다.")
+        @Test
+        void kakaoSigninFailedWhenYearIdIsMoreThanMax() throws Exception {
+            // given
+            KakaoSigninRequest request = new KakaoSigninRequest(MOCK_ACCESS_TOKEN, MOCK_NICKNAME, MOCK_BIRTH,
+                    Gender.FEMALE, 1L, 5);
+
+            // when // then
+            mockMvc.perform(post("/api/v1/auth/signin/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is(400))
+                    .andExpect(jsonPath("$.message").value("yearId는 4 이하의 값이어야 합니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
+        }
+
+    }
+
+}

--- a/src/test/java/com/challenge/api/controller/category/CategoryControllerTest.java
+++ b/src/test/java/com/challenge/api/controller/category/CategoryControllerTest.java
@@ -1,14 +1,12 @@
 package com.challenge.api.controller.category;
 
+import com.challenge.api.controller.ControllerTestSupport;
 import com.challenge.api.service.category.CategoryService;
 import com.challenge.api.service.category.response.CategoryResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
@@ -18,12 +16,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ActiveProfiles("test")
 @WebMvcTest(controllers = CategoryController.class)
-class CategoryControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
+class CategoryControllerTest extends ControllerTestSupport {
 
     @MockBean
     private CategoryService categoryService;

--- a/src/test/java/com/challenge/api/service/auth/AuthServiceTest.java
+++ b/src/test/java/com/challenge/api/service/auth/AuthServiceTest.java
@@ -1,0 +1,211 @@
+package com.challenge.api.service.auth;
+
+import com.challenge.api.service.auth.request.KakaoLoginServiceRequest;
+import com.challenge.api.service.auth.request.KakaoSigninServiceRequest;
+import com.challenge.api.service.auth.response.LoginResponse;
+import com.challenge.api.service.auth.response.SocialInfoResponse;
+import com.challenge.domain.job.Job;
+import com.challenge.domain.job.JobRepository;
+import com.challenge.domain.member.Gender;
+import com.challenge.domain.member.JobYear;
+import com.challenge.domain.member.LoginType;
+import com.challenge.domain.member.Member;
+import com.challenge.domain.member.MemberRepository;
+import com.challenge.exception.GlobalException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+public class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @MockBean
+    private KakaoApiService kakaoApiService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JobRepository jobRepository;
+
+    private Job job;
+
+    private static final Long MOCK_SOCIAL_ID = 1L;
+    private static final String MOCK_EMAIL = "test@naver.com";
+    private static final String MOCK_NICKNAME = "test";
+    private static final LocalDate MOCK_BIRTH = LocalDate.of(2000, 1, 1);
+    private static final String MOCK_KAKAO_ACCESS_TOKEN = "test-access-token";
+
+    @BeforeEach
+    void setUp() {
+        // Job 데이터 저장
+        job = Job.builder()
+                .code("1")
+                .description("1")
+                .build();
+        job = jobRepository.save(job);
+    }
+
+    private Member createMember() {
+        return memberRepository.save(Member.builder()
+                .socialId(MOCK_SOCIAL_ID)
+                .email(MOCK_EMAIL)
+                .loginType(LoginType.KAKAO)
+                .nickname(MOCK_NICKNAME)
+                .birth(MOCK_BIRTH)
+                .gender(Gender.MALE)
+                .jobYear(JobYear.LT_1Y)
+                .job(job)
+                .build());
+    }
+
+    private SocialInfoResponse createMockSocialInfoResponse(Long socialId, LoginType loginType) {
+        return SocialInfoResponse.builder()
+                .socialId(socialId)
+                .email(MOCK_EMAIL)
+                .loginType(loginType)
+                .build();
+    }
+
+    private void mockKakaoApiResponse(Long socialId, LoginType loginType) {
+        given(kakaoApiService.getUserInfo(MOCK_KAKAO_ACCESS_TOKEN)).willReturn(createMockSocialInfoResponse(socialId,
+                loginType));
+    }
+
+    @DisplayName("카카오 로그인 성공: 토큰과 회원id가 반환된다.")
+    @Test
+    void kakaoLoginSucceeds() {
+        // given
+        Member member = createMember();
+
+        // 카카오 API 호출 mock 처리
+        mockKakaoApiResponse(MOCK_SOCIAL_ID, LoginType.KAKAO);
+
+        // request 값 세팅
+        KakaoLoginServiceRequest request = KakaoLoginServiceRequest.builder()
+                .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                .build();
+
+        // when
+        LoginResponse response = authService.kakaoLogin(request);
+
+        // then
+        assertThat(response.getMemberId()).isEqualTo(member.getId());
+        assertThat(response.getAccessToken()).isNotEmpty();
+        assertThat(response.getRefreshToken()).isNotEmpty();
+    }
+
+    @DisplayName("카카오 로그인 실패: 가입된 회원 정보가 없는 경우 예외가 발생한다.")
+    @Test
+    void kakaoLoginFailedWhenMemberNotFound() {
+        // given
+        // 카카오 API 호출 mock 처리
+        mockKakaoApiResponse(MOCK_SOCIAL_ID, LoginType.KAKAO);
+
+        // request 값 세팅
+        KakaoLoginServiceRequest request = KakaoLoginServiceRequest.builder()
+                .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> authService.kakaoLogin(request))
+                .isInstanceOf(GlobalException.class)
+                .hasMessage("사용자를 찾을 수 없습니다.");
+    }
+
+    @DisplayName("카카오 회원가입 성공: 토큰과 회원id가 반환된다.")
+    @Test
+    void kakaoSigninSucceeds() {
+        // given
+        // 카카오 API 호출 mock 처리
+        mockKakaoApiResponse(MOCK_SOCIAL_ID, LoginType.KAKAO);
+
+        // request 값 세팅
+        KakaoSigninServiceRequest request = KakaoSigninServiceRequest.builder()
+                .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                .nickname(MOCK_NICKNAME)
+                .birth(MOCK_BIRTH)
+                .gender(Gender.FEMALE)
+                .jobId(job.getId())
+                .yearId(1)
+                .build();
+
+        // when
+        LoginResponse response = authService.kakaoSignin(request);
+
+        // then
+        Member savedMember = memberRepository.findBySocialIdAndLoginType(MOCK_SOCIAL_ID, LoginType.KAKAO);
+        assertThat(response.getMemberId()).isEqualTo(savedMember.getId());
+        assertThat(response.getAccessToken()).isNotEmpty();
+        assertThat(response.getRefreshToken()).isNotEmpty();
+    }
+
+    @DisplayName("카카오 회원가입 실패: 이미 가입된 회원인 경우 예외가 발생한다.")
+    @Test
+    void kakaoSigninFailedWhenExistMember() {
+        // given
+        // 회원 데이터 생성
+        createMember();
+
+        // 카카오 API 호출 mock 처리
+        mockKakaoApiResponse(MOCK_SOCIAL_ID, LoginType.KAKAO);
+
+        // request 값 세팅
+        KakaoSigninServiceRequest request = KakaoSigninServiceRequest.builder()
+                .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                .nickname(MOCK_NICKNAME)
+                .birth(MOCK_BIRTH)
+                .gender(Gender.FEMALE)
+                .jobId(job.getId())
+                .yearId(1)
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> authService.kakaoSignin(request))
+                .isInstanceOf(GlobalException.class)
+                .hasMessage("이미 존재하는 회원입니다.");
+    }
+
+    @DisplayName("카카오 회원가입 실패: 중복된 닉네임을 요청하는 경우 예외가 발생한다.")
+    @Test
+    void kakaoSigninFailedWhenDuplicatedNickname() {
+        // given
+        // 회원 데이터 생성
+        createMember();
+
+        // 카카오 API 호출 mock 처리
+        mockKakaoApiResponse(2L, LoginType.KAKAO);
+
+        // request 값 세팅
+        KakaoSigninServiceRequest request = KakaoSigninServiceRequest.builder()
+                .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
+                .nickname(MOCK_NICKNAME) // 동일한 닉네임으로 요청
+                .birth(MOCK_BIRTH)
+                .gender(Gender.FEMALE)
+                .jobId(job.getId())
+                .yearId(1)
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> authService.kakaoSignin(request))
+                .isInstanceOf(GlobalException.class)
+                .hasMessage("이미 사용중인 닉네임입니다.");
+    }
+
+}

--- a/src/test/java/com/challenge/api/service/auth/AuthServiceTest.java
+++ b/src/test/java/com/challenge/api/service/auth/AuthServiceTest.java
@@ -83,9 +83,9 @@ public class AuthServiceTest {
                 .build();
     }
 
-    private void mockKakaoApiResponse(Long socialId, LoginType loginType) {
+    private void mockKakaoApiResponse(Long socialId) {
         given(kakaoApiService.getUserInfo(MOCK_KAKAO_ACCESS_TOKEN)).willReturn(createMockSocialInfoResponse(socialId,
-                loginType));
+                LoginType.KAKAO));
     }
 
     @DisplayName("카카오 로그인 성공: 토큰과 회원id가 반환된다.")
@@ -95,7 +95,7 @@ public class AuthServiceTest {
         Member member = createMember();
 
         // 카카오 API 호출 mock 처리
-        mockKakaoApiResponse(MOCK_SOCIAL_ID, LoginType.KAKAO);
+        mockKakaoApiResponse(MOCK_SOCIAL_ID);
 
         // request 값 세팅
         KakaoLoginServiceRequest request = KakaoLoginServiceRequest.builder()
@@ -116,7 +116,7 @@ public class AuthServiceTest {
     void kakaoLoginFailedWhenMemberNotFound() {
         // given
         // 카카오 API 호출 mock 처리
-        mockKakaoApiResponse(MOCK_SOCIAL_ID, LoginType.KAKAO);
+        mockKakaoApiResponse(MOCK_SOCIAL_ID);
 
         // request 값 세팅
         KakaoLoginServiceRequest request = KakaoLoginServiceRequest.builder()
@@ -134,7 +134,7 @@ public class AuthServiceTest {
     void kakaoSigninSucceeds() {
         // given
         // 카카오 API 호출 mock 처리
-        mockKakaoApiResponse(MOCK_SOCIAL_ID, LoginType.KAKAO);
+        mockKakaoApiResponse(MOCK_SOCIAL_ID);
 
         // request 값 세팅
         KakaoSigninServiceRequest request = KakaoSigninServiceRequest.builder()
@@ -164,7 +164,7 @@ public class AuthServiceTest {
         createMember();
 
         // 카카오 API 호출 mock 처리
-        mockKakaoApiResponse(MOCK_SOCIAL_ID, LoginType.KAKAO);
+        mockKakaoApiResponse(MOCK_SOCIAL_ID);
 
         // request 값 세팅
         KakaoSigninServiceRequest request = KakaoSigninServiceRequest.builder()
@@ -190,7 +190,7 @@ public class AuthServiceTest {
         createMember();
 
         // 카카오 API 호출 mock 처리
-        mockKakaoApiResponse(2L, LoginType.KAKAO);
+        mockKakaoApiResponse(2L);
 
         // request 값 세팅
         KakaoSigninServiceRequest request = KakaoSigninServiceRequest.builder()

--- a/src/test/java/com/challenge/api/service/auth/AuthServiceTest.java
+++ b/src/test/java/com/challenge/api/service/auth/AuthServiceTest.java
@@ -62,32 +62,6 @@ public class AuthServiceTest {
         job = jobRepository.save(job);
     }
 
-    private Member createMember() {
-        return memberRepository.save(Member.builder()
-                .socialId(MOCK_SOCIAL_ID)
-                .email(MOCK_EMAIL)
-                .loginType(LoginType.KAKAO)
-                .nickname(MOCK_NICKNAME)
-                .birth(MOCK_BIRTH)
-                .gender(Gender.MALE)
-                .jobYear(JobYear.LT_1Y)
-                .job(job)
-                .build());
-    }
-
-    private SocialInfoResponse createMockSocialInfoResponse(Long socialId, LoginType loginType) {
-        return SocialInfoResponse.builder()
-                .socialId(socialId)
-                .email(MOCK_EMAIL)
-                .loginType(loginType)
-                .build();
-    }
-
-    private void mockKakaoApiResponse(Long socialId) {
-        given(kakaoApiService.getUserInfo(MOCK_KAKAO_ACCESS_TOKEN)).willReturn(createMockSocialInfoResponse(socialId,
-                LoginType.KAKAO));
-    }
-
     @DisplayName("카카오 로그인 성공: 토큰과 회원id가 반환된다.")
     @Test
     void kakaoLoginSucceeds() {
@@ -206,6 +180,33 @@ public class AuthServiceTest {
         assertThatThrownBy(() -> authService.kakaoSignin(request))
                 .isInstanceOf(GlobalException.class)
                 .hasMessage("이미 사용중인 닉네임입니다.");
+    }
+
+    /*   테스트 공통 메소드   */
+    private Member createMember() {
+        return memberRepository.save(Member.builder()
+                .socialId(MOCK_SOCIAL_ID)
+                .email(MOCK_EMAIL)
+                .loginType(LoginType.KAKAO)
+                .nickname(MOCK_NICKNAME)
+                .birth(MOCK_BIRTH)
+                .gender(Gender.MALE)
+                .jobYear(JobYear.LT_1Y)
+                .job(job)
+                .build());
+    }
+
+    private SocialInfoResponse createMockSocialInfoResponse(Long socialId, LoginType loginType) {
+        return SocialInfoResponse.builder()
+                .socialId(socialId)
+                .email(MOCK_EMAIL)
+                .loginType(loginType)
+                .build();
+    }
+
+    private void mockKakaoApiResponse(Long socialId) {
+        given(kakaoApiService.getUserInfo(MOCK_KAKAO_ACCESS_TOKEN))
+                .willReturn(createMockSocialInfoResponse(socialId, LoginType.KAKAO));
     }
 
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- Member 엔티티의 year 필드 이름 변경 (year -> jobYear)
- 카카오 로그인/회원가입 서비스 테스트코드 작성
- 카카오 로그인/회원가입 컨트롤러 테스트코드 작성
- 인터셉터 및 커스텀 어노테이션 리졸버 mock 처리를 위한 ControllerTestSupport 구현
- request dto 검증 message 추가

## ⏳ 작업 내용
- [x] Member 엔티티의 year 필드 이름 변경
- [x] 카카오 로그인/회원가입 서비스 테스트코드 작성
- [x] 카카오 로그인/회원가입 컨트롤러 테스트코드 작성
- [x] ControllerTestSupport 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
기존 코드에서는 컨트롤러 테스트에서 필요한 request dto를 생성할 수 없어서 request dto마다 @AllArgsConstructor 추가했습니다.

