### PR TITLE
[Feat/30] 토큰 재발급 API 구현 및 테스트

### DIFF
--- a/src/main/java/com/challenge/api/controller/auth/AuthController.java
+++ b/src/main/java/com/challenge/api/controller/auth/AuthController.java
@@ -3,8 +3,10 @@ package com.challenge.api.controller.auth;
 import com.challenge.api.ApiResponse;
 import com.challenge.api.controller.auth.request.KakaoLoginRequest;
 import com.challenge.api.controller.auth.request.KakaoSigninRequest;
+import com.challenge.api.controller.auth.request.ReissueTokenRequest;
 import com.challenge.api.service.auth.AuthService;
 import com.challenge.api.service.auth.response.LoginResponse;
+import com.challenge.api.service.auth.response.ReissueTokenResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,6 +29,11 @@ public class AuthController {
     @PostMapping("/signin/kakao")
     public ApiResponse<LoginResponse> kakaoSignin(@RequestBody @Valid KakaoSigninRequest request) {
         return ApiResponse.ok(authService.kakaoSignin(request.toServiceRequest()));
+    }
+
+    @PostMapping("/reissue")
+    public ApiResponse<ReissueTokenResponse> reissueToken(@RequestBody @Valid ReissueTokenRequest request) {
+        return ApiResponse.ok(authService.reissueToken(request.toServiceRequest()));
     }
 
 }

--- a/src/main/java/com/challenge/api/controller/auth/request/ReissueTokenRequest.java
+++ b/src/main/java/com/challenge/api/controller/auth/request/ReissueTokenRequest.java
@@ -1,0 +1,25 @@
+package com.challenge.api.controller.auth.request;
+
+import com.challenge.api.service.auth.request.ReissueTokenServiceRequest;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReissueTokenRequest {
+
+    private String refreshToken;
+
+    public ReissueTokenServiceRequest toServiceRequest() {
+        return ReissueTokenServiceRequest.builder()
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    @Builder
+    private ReissueTokenRequest(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+}

--- a/src/main/java/com/challenge/api/controller/auth/request/ReissueTokenRequest.java
+++ b/src/main/java/com/challenge/api/controller/auth/request/ReissueTokenRequest.java
@@ -1,6 +1,7 @@
 package com.challenge.api.controller.auth.request;
 
 import com.challenge.api.service.auth.request.ReissueTokenServiceRequest;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ReissueTokenRequest {
 
+    @NotBlank(message = "refresh token은 필수 입력값입니다.")
     private String refreshToken;
 
     public ReissueTokenServiceRequest toServiceRequest() {

--- a/src/main/java/com/challenge/api/service/auth/request/ReissueTokenServiceRequest.java
+++ b/src/main/java/com/challenge/api/service/auth/request/ReissueTokenServiceRequest.java
@@ -1,0 +1,18 @@
+package com.challenge.api.service.auth.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReissueTokenServiceRequest {
+
+    private String refreshToken;
+
+    @Builder
+    private ReissueTokenServiceRequest(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+}

--- a/src/main/java/com/challenge/api/service/auth/response/ReissueTokenResponse.java
+++ b/src/main/java/com/challenge/api/service/auth/response/ReissueTokenResponse.java
@@ -1,0 +1,28 @@
+package com.challenge.api.service.auth.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReissueTokenResponse {
+
+    private final String accessToken;
+    private final String refreshToken;
+    private final Long accessTokenExpiresIn;
+
+    @Builder
+    private ReissueTokenResponse(String accessToken, String refreshToken, Long accessTokenExpiresIn) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.accessTokenExpiresIn = accessTokenExpiresIn;
+    }
+
+    public static ReissueTokenResponse of(String accessToken, String refreshToken, Long accessTokenExpiresIn) {
+        return ReissueTokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessTokenExpiresIn(accessTokenExpiresIn)
+                .build();
+    }
+
+}

--- a/src/main/java/com/challenge/api/validator/auth/AuthValidator.java
+++ b/src/main/java/com/challenge/api/validator/auth/AuthValidator.java
@@ -20,7 +20,7 @@ public class AuthValidator {
      *
      * @param userInfo
      */
-    public void validateMemberExists(SocialInfoResponse userInfo) {
+    public void validateMemberExistsBySocialInfo(SocialInfoResponse userInfo) {
         boolean exists = memberRepository.existsBySocialIdAndLoginType(userInfo.getSocialId(), userInfo.getLoginType());
         if (!exists) {
             throw new GlobalException(ErrorCode.MEMBER_NOT_FOUND);
@@ -32,10 +32,22 @@ public class AuthValidator {
      *
      * @param userInfo
      */
-    public void validateMemberNotExists(SocialInfoResponse userInfo) {
+    public void validateMemberNotExistsBySocialInfo(SocialInfoResponse userInfo) {
         boolean exists = memberRepository.existsBySocialIdAndLoginType(userInfo.getSocialId(), userInfo.getLoginType());
         if (exists) {
             throw new GlobalException(ErrorCode.MEMBER_EXISTS);
+        }
+    }
+
+    /**
+     * memberId에 해당하는 사용자가 존재하는지 검증하는 메소드
+     *
+     * @param memberId
+     */
+    public void validateMemberExistsById(Long memberId) {
+        boolean exists = memberRepository.existsById(memberId);
+        if (!exists) {
+            throw new GlobalException(ErrorCode.MEMBER_NOT_FOUND);
         }
     }
 

--- a/src/main/java/com/challenge/exception/ErrorCode.java
+++ b/src/main/java/com/challenge/exception/ErrorCode.java
@@ -35,7 +35,7 @@ public enum ErrorCode {
     UNSUPPORTED_TOKEN(UNAUTHORIZED, "AUTH_4005", "지원되지 않는 JWT입니다."),
     EXPIRED_JWT_EXCEPTION(UNAUTHORIZED, "AUTH_4006", "기존 토큰이 만료되었습니다. 토큰을 재발급해주세요."),
     INVALID_CLAIMS(UNAUTHORIZED, "AUTH_4007", "JWT의 클레임이 유효하지 않습니다."),
-    INVALID_REFRESH_TOKEN(BAD_REQUEST, "AUTH_4008", "리프레쉬 토큰이 유효하지 않습니다. 다시 로그인 해주세요"),
+    EXPIRED_REFRESH_TOKEN(BAD_REQUEST, "AUTH_4008", "리프레쉬 토큰이 만료되었습니다. 다시 로그인 해주세요"),
     UNAUTHORIZED_EXCEPTION(UNAUTHORIZED, "AUTH_4009", "로그인 후 이용가능합니다. 토큰을 입력해 주세요"),
     MEMBER_EXTRACTION_FAILED(NOT_FOUND, "AUTH_4010", "회원 정보를 추출할 수 없습니다."),
     INACTIVE_MEMBER(NOT_FOUND, "AUTH_4011", "탈퇴한 사용자 입니다."),

--- a/src/main/java/com/challenge/utils/JwtUtil.java
+++ b/src/main/java/com/challenge/utils/JwtUtil.java
@@ -57,7 +57,10 @@ public class JwtUtil {
      * @return
      */
     public String createRefreshToken(Long memberId) {
-        return createToken(memberId, refreshExpireDay);
+        // refreshExpireDay를 밀리초 단위로 변환
+        long refreshExpireTimeInMillis = refreshExpireDay * 24 * 60 * 60 * 1000;
+
+        return createToken(memberId, refreshExpireTimeInMillis);
     }
 
     /**

--- a/src/main/java/com/challenge/utils/JwtUtil.java
+++ b/src/main/java/com/challenge/utils/JwtUtil.java
@@ -129,6 +129,16 @@ public class JwtUtil {
     }
 
     /**
+     * 테스트를 위한 만료 시간이 짧은 refresh token 발급 메소드
+     *
+     * @param memberId
+     * @return
+     */
+    public String createRefreshTokenForTest(Long memberId) {
+        return createToken(memberId, 1L);
+    }
+
+    /**
      * token 생성 메소드
      *
      * @param memberId

--- a/src/main/java/com/challenge/utils/JwtUtil.java
+++ b/src/main/java/com/challenge/utils/JwtUtil.java
@@ -129,16 +129,6 @@ public class JwtUtil {
     }
 
     /**
-     * 테스트를 위한 만료 시간이 짧은 refresh token 발급 메소드
-     *
-     * @param memberId
-     * @return
-     */
-    public String createRefreshTokenForTest(Long memberId) {
-        return createToken(memberId, 1L);
-    }
-
-    /**
      * token 생성 메소드
      *
      * @param memberId
@@ -172,6 +162,16 @@ public class JwtUtil {
         } catch (ExpiredJwtException e) {
             return e.getClaims();
         }
+    }
+
+    /**
+     * 테스트를 위한 만료 시간이 짧은 refresh token 발급 메소드
+     *
+     * @param memberId
+     * @return
+     */
+    public String createRefreshTokenForTest(Long memberId) {
+        return createToken(memberId, 1L);
     }
 
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 토큰 재발급 API 구현
- 토큰 재발급 서비스 테스트코드 작성
- 토큰 재발급 컨트롤러 테스트코드 작성
- jwtUtil의 createRefreshToken 메소드 수정 (만료 시간을 일 -> 밀리초로 환산해 토큰 생성하도록)
- jwtUtil에 만료시간이 짧은 refresh token 발급 메소드 추가

## ⏳ 작업 내용
- [x] 토큰 재발급 API 구현
- [x] 토큰 재발급 서비스 테스트코드 작성
- [x] 토큰 재발급 컨트롤러 테스트코드 작성
- [x] jwtUtil 메소드 수정 및 추가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
refresh token이 만료된 경우에 대한 테스트를 위해서 createRefreshTokenForTest 메소드를 추가했는데.. 이렇게 해도 되는건지 모르겠네요 ㅠㅠ
