### PR TITLE
[Feat/34] 닉네임 중복 확인 API 구현 및 테스트

### DIFF
--- a/src/main/java/com/challenge/api/controller/member/MemberController.java
+++ b/src/main/java/com/challenge/api/controller/member/MemberController.java
@@ -1,0 +1,25 @@
+package com.challenge.api.controller.member;
+
+import com.challenge.api.ApiResponse;
+import com.challenge.api.controller.member.request.CheckNicknameRequest;
+import com.challenge.api.service.member.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/nickname/valid")
+    public ApiResponse<String> checkNicknameIsValid(@RequestBody @Valid CheckNicknameRequest request) {
+        return ApiResponse.ok(memberService.checkNicknameIsValid(request.toServiceRequest()));
+    }
+
+}

--- a/src/main/java/com/challenge/api/controller/member/request/CheckNicknameRequest.java
+++ b/src/main/java/com/challenge/api/controller/member/request/CheckNicknameRequest.java
@@ -1,0 +1,27 @@
+package com.challenge.api.controller.member.request;
+
+import com.challenge.api.service.member.request.CheckNicknameServiceRequest;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CheckNicknameRequest {
+
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9]{4,10}$", message = "닉네임은 4~10자이며, 띄어쓰기와 특수문자를 사용할 수 없습니다.")
+    private String nickname;
+
+    public CheckNicknameServiceRequest toServiceRequest() {
+        return CheckNicknameServiceRequest.builder()
+                .nickname(nickname)
+                .build();
+    }
+
+    @Builder
+    private CheckNicknameRequest(String nickname) {
+        this.nickname = nickname;
+    }
+
+}

--- a/src/main/java/com/challenge/api/service/member/MemberService.java
+++ b/src/main/java/com/challenge/api/service/member/MemberService.java
@@ -1,0 +1,36 @@
+package com.challenge.api.service.member;
+
+import com.challenge.api.service.member.request.CheckNicknameServiceRequest;
+import com.challenge.domain.member.MemberRepository;
+import com.challenge.exception.ErrorCode;
+import com.challenge.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * 해당 닉네임이 사용 가능 여부를 조회하는 메소드
+     *
+     * @param request
+     * @return
+     */
+    public String checkNicknameIsValid(CheckNicknameServiceRequest request) {
+        String nickname = request.getNickname();
+
+        // 다른 회원이 사용중인 닉네임인 경우
+        boolean exists = memberRepository.existsByNickname(nickname);
+        if (exists) {
+            throw new GlobalException(ErrorCode.DUPLICATED_NICKNAME);
+        }
+
+        return "사용 가능한 닉네임입니다.";
+    }
+
+}

--- a/src/main/java/com/challenge/api/service/member/request/CheckNicknameServiceRequest.java
+++ b/src/main/java/com/challenge/api/service/member/request/CheckNicknameServiceRequest.java
@@ -1,0 +1,18 @@
+package com.challenge.api.service.member.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CheckNicknameServiceRequest {
+
+    private String nickname;
+
+    @Builder
+    private CheckNicknameServiceRequest(String nickname) {
+        this.nickname = nickname;
+    }
+
+}

--- a/src/main/java/com/challenge/config/WebConfig.java
+++ b/src/main/java/com/challenge/config/WebConfig.java
@@ -17,7 +17,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final AuthMemberArgumentResolver authMemberArgumentResolver;
     private final AuthInterceptor authInterceptor;
-    private final List<String> excludeEndpoints = Arrays.asList("/api/v1/auth/**");
+    private final List<String> excludeEndpoints = Arrays.asList("/api/v1/auth/**", "/api/v1/member/nickname/valid");
 
     // 인터셉터 설정
     @Override

--- a/src/test/java/com/challenge/api/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/challenge/api/controller/member/MemberControllerTest.java
@@ -1,0 +1,78 @@
+package com.challenge.api.controller.member;
+
+import com.challenge.api.controller.ControllerTestSupport;
+import com.challenge.api.controller.member.request.CheckNicknameRequest;
+import com.challenge.api.service.member.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+public class MemberControllerTest extends ControllerTestSupport {
+
+    @MockBean
+    private MemberService memberService;
+
+    private String checkNicknameResponse;
+
+    @Nested
+    @DisplayName("닉네임 중복 확인")
+    class CheckNicknameIsValidTests {
+
+        @BeforeEach
+        void setUp() {
+            // 서비스 mock 처리
+            checkNicknameResponse = "사용 가능한 닉네임입니다.";
+            given(memberService.checkNicknameIsValid(any())).willReturn(checkNicknameResponse);
+        }
+
+        @DisplayName("닉네임 중복 확인 성공")
+        @Test
+        void checkNicknameIsValidSucceeds() throws Exception {
+            // given
+            CheckNicknameRequest request = CheckNicknameRequest.builder()
+                    .nickname("nickname")
+                    .build();
+
+            // when // then
+            mockMvc.perform(post("/api/v1/member/nickname/valid")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("OK"))
+                    .andExpect(jsonPath("$.code").isEmpty())
+                    .andExpect(jsonPath("$.url").isEmpty())
+                    .andExpect(jsonPath("$.data").value(checkNicknameResponse));
+        }
+
+        @DisplayName("닉네임 중복 확인 실패: nickname이 공백인 경우 에러 응답을 반환한다.")
+        @Test
+        void checkNicknameIsValidFailed() throws Exception {
+            // given
+            CheckNicknameRequest request = CheckNicknameRequest.builder()
+                    .nickname(" ")
+                    .build();
+
+            // when // then
+            mockMvc.perform(post("/api/v1/member/nickname/valid")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is(400))
+                    .andExpect(jsonPath("$.message").value("닉네임은 4~10자이며, 띄어쓰기와 특수문자를 사용할 수 없습니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.url").value("/api/v1/member/nickname/valid"));
+        }
+
+    }
+
+}

--- a/src/test/java/com/challenge/api/service/member/MemberServiceTest.java
+++ b/src/test/java/com/challenge/api/service/member/MemberServiceTest.java
@@ -1,0 +1,104 @@
+package com.challenge.api.service.member;
+
+import com.challenge.api.service.member.request.CheckNicknameServiceRequest;
+import com.challenge.domain.job.Job;
+import com.challenge.domain.job.JobRepository;
+import com.challenge.domain.member.Gender;
+import com.challenge.domain.member.JobYear;
+import com.challenge.domain.member.LoginType;
+import com.challenge.domain.member.Member;
+import com.challenge.domain.member.MemberRepository;
+import com.challenge.exception.GlobalException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+public class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JobRepository jobRepository;
+
+    private static final Long MOCK_SOCIAL_ID = 1L;
+    private static final String MOCK_EMAIL = "test@naver.com";
+    private static final String MOCK_NICKNAME = "test";
+    private static final LocalDate MOCK_BIRTH = LocalDate.of(2000, 1, 1);
+
+    private Job job;
+
+    @BeforeEach
+    void setUp() {
+        // Job 데이터 저장
+        job = Job.builder()
+                .code("1")
+                .description("1")
+                .build();
+        job = jobRepository.save(job);
+    }
+
+    @DisplayName("닉네임 중복 확인 성공: 닉네임 사용 가능 메시지가 반환된다.")
+    @Test
+    void checkNicknameIsValidSucceeds() {
+        // given
+        // request 값 세팅
+        CheckNicknameServiceRequest request = CheckNicknameServiceRequest.builder()
+                .nickname("new nickname")
+                .build();
+
+        // when
+        String response = memberService.checkNicknameIsValid(request);
+
+        // then
+        assertThat(response).isEqualTo("사용 가능한 닉네임입니다.");
+    }
+
+    @DisplayName("닉네임 중복 확인 실패: 이미 사용중인 닉네임인 경우 예외가 발생한다.")
+    @Test
+    void checkNicknameIsValidFailed() {
+        // given
+        createMember();
+
+        // request 값 세팅
+        CheckNicknameServiceRequest request = CheckNicknameServiceRequest.builder()
+                .nickname(MOCK_NICKNAME)
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> memberService.checkNicknameIsValid(request))
+                .isInstanceOf(GlobalException.class)
+                .hasMessage("이미 사용중인 닉네임입니다.");
+    }
+
+    /*   테스트 공통 메소드   */
+    private Member createMember() {
+        return memberRepository.save(Member.builder()
+                .socialId(MOCK_SOCIAL_ID)
+                .email(MOCK_EMAIL)
+                .loginType(LoginType.KAKAO)
+                .nickname(MOCK_NICKNAME)
+                .birth(MOCK_BIRTH)
+                .gender(Gender.MALE)
+                .jobYear(JobYear.LT_1Y)
+                .job(job)
+                .build());
+    }
+
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
닉네임 중복 확인 API 구현 및 테스트

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 닉네임 중복 확인 API 구현
- 닉네임 중복 확인 API 서비스 테스트
- 닉네임 중복 확인 API 컨트롤러 테스트
- 인터셉터 적용하지 않는 endpoint 설정 추가

## ⏳ 작업 내용
- [x] 닉네임 중복 확인 API 구현
- [x] 닉네임 중복 확인 API 서비스 테스트
- [x] 닉네임 중복 확인 API 컨트롤러 테스트

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
