### PR TITLE
[Feat/33] 내 회원 정보 조회 API 구현 및 테스트

### DIFF
--- a/src/main/java/com/challenge/api/controller/member/MemberController.java
+++ b/src/main/java/com/challenge/api/controller/member/MemberController.java
@@ -1,0 +1,24 @@
+package com.challenge.api.controller.member;
+
+import com.challenge.annotation.AuthMember;
+import com.challenge.api.ApiResponse;
+import com.challenge.api.service.member.MemberService;
+import com.challenge.domain.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping
+    public ApiResponse<Object> getMemberInfo(@AuthMember Member member) {
+        return ApiResponse.ok(memberService.getMemberInfo(member));
+    }
+
+}

--- a/src/main/java/com/challenge/api/controller/member/MemberController.java
+++ b/src/main/java/com/challenge/api/controller/member/MemberController.java
@@ -3,6 +3,7 @@ package com.challenge.api.controller.member;
 import com.challenge.annotation.AuthMember;
 import com.challenge.api.ApiResponse;
 import com.challenge.api.service.member.MemberService;
+import com.challenge.api.service.member.response.MemberInfoResponse;
 import com.challenge.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,7 +18,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping
-    public ApiResponse<Object> getMemberInfo(@AuthMember Member member) {
+    public ApiResponse<MemberInfoResponse> getMemberInfo(@AuthMember Member member) {
         return ApiResponse.ok(memberService.getMemberInfo(member));
     }
 

--- a/src/main/java/com/challenge/api/service/member/MemberService.java
+++ b/src/main/java/com/challenge/api/service/member/MemberService.java
@@ -1,0 +1,25 @@
+package com.challenge.api.service.member;
+
+
+import com.challenge.api.service.member.response.MemberInfoResponse;
+import com.challenge.domain.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    /**
+     * 회원 정보 조회 메소드
+     *
+     * @param member
+     * @return
+     */
+    public MemberInfoResponse getMemberInfo(Member member) {
+        return MemberInfoResponse.of(member);
+    }
+
+}

--- a/src/main/java/com/challenge/api/service/member/response/MemberInfoResponse.java
+++ b/src/main/java/com/challenge/api/service/member/response/MemberInfoResponse.java
@@ -1,0 +1,41 @@
+package com.challenge.api.service.member.response;
+
+import com.challenge.domain.member.Gender;
+import com.challenge.domain.member.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class MemberInfoResponse {
+
+    private final String nickname;
+    private final LocalDate birth;
+    private final Gender gender;
+    private final long jobId;
+    private final String job;
+    private final int jobYearId;
+
+    @Builder
+    private MemberInfoResponse(String nickname, LocalDate birth, Gender gender, long jobId, String job, int jobYearId) {
+        this.nickname = nickname;
+        this.birth = birth;
+        this.gender = gender;
+        this.jobId = jobId;
+        this.job = job;
+        this.jobYearId = jobYearId;
+    }
+
+    public static MemberInfoResponse of(Member member) {
+        return MemberInfoResponse.builder()
+                .nickname(member.getNickname())
+                .birth(member.getBirth())
+                .gender(member.getGender())
+                .jobId(member.getJob().getId())
+                .job(member.getJob().getDescription())
+                .jobYearId(member.getJobYear().getId())
+                .build();
+    }
+
+}

--- a/src/main/java/com/challenge/domain/job/Job.java
+++ b/src/main/java/com/challenge/domain/job/Job.java
@@ -27,7 +27,8 @@ public class Job {
     private String description;
 
     @Builder
-    private Job(String code, String description) {
+    private Job(Long id, String code, String description) {
+        this.id = id;
         this.code = code;
         this.description = description;
     }

--- a/src/test/java/com/challenge/api/controller/ControllerTestSupport.java
+++ b/src/test/java/com/challenge/api/controller/ControllerTestSupport.java
@@ -2,6 +2,7 @@ package com.challenge.api.controller;
 
 import com.challenge.annotation.resolver.AuthMemberArgumentResolver;
 import com.challenge.api.interceptor.AuthInterceptor;
+import com.challenge.domain.job.Job;
 import com.challenge.domain.member.Gender;
 import com.challenge.domain.member.JobYear;
 import com.challenge.domain.member.LoginType;
@@ -39,6 +40,11 @@ public class ControllerTestSupport {
     protected static final String MOCK_EMAIL = "test@naver.com";
     protected static final String MOCK_NICKNAME = "test";
     protected static final LocalDate MOCK_BIRTH = LocalDate.of(2000, 1, 1);
+    protected static final Gender MOCK_GENDER = Gender.MALE;
+    protected static final JobYear MOCK_JOBYEAR = JobYear.LT_1Y;
+    protected static final Job MOCK_JOB = Job.builder().id(1L).code("1").description("1").build();
+
+    protected Member mockMember;
 
     @BeforeEach
     public void baseSetUp() throws Exception {
@@ -46,14 +52,16 @@ public class ControllerTestSupport {
         given(authInterceptor.preHandle(any(), any(), any())).willReturn(true);
 
         // 리졸버가 mockMember를 반환하도록 Mock 설정
-        Member mockMember = Member.builder()
+
+        mockMember = Member.builder()
                 .socialId(MOCK_SOCIAL_ID)
                 .email(MOCK_EMAIL)
                 .loginType(LoginType.KAKAO)
                 .nickname(MOCK_NICKNAME)
                 .birth(MOCK_BIRTH)
-                .gender(Gender.MALE)
-                .jobYear(JobYear.LT_1Y)
+                .gender(MOCK_GENDER)
+                .jobYear(MOCK_JOBYEAR)
+                .job(MOCK_JOB)
                 .build();
         given(authMemberArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(mockMember);
     }

--- a/src/test/java/com/challenge/api/controller/auth/AuthControllerTest.java
+++ b/src/test/java/com/challenge/api/controller/auth/AuthControllerTest.java
@@ -7,7 +7,6 @@ import com.challenge.api.controller.auth.request.ReissueTokenRequest;
 import com.challenge.api.service.auth.AuthService;
 import com.challenge.api.service.auth.response.LoginResponse;
 import com.challenge.api.service.auth.response.ReissueTokenResponse;
-import com.challenge.domain.member.Gender;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -115,9 +114,9 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
                     .nickname(MOCK_NICKNAME)
                     .birth(MOCK_BIRTH)
-                    .gender(Gender.FEMALE)
-                    .jobId(1L)
-                    .yearId(1)
+                    .gender(MOCK_GENDER)
+                    .jobId(MOCK_JOB.getId())
+                    .yearId(MOCK_JOBYEAR.getId())
                     .build();
 
             // when // then
@@ -141,9 +140,9 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .accessToken(" ")
                     .nickname(MOCK_NICKNAME)
                     .birth(MOCK_BIRTH)
-                    .gender(Gender.FEMALE)
-                    .jobId(1L)
-                    .yearId(1)
+                    .gender(MOCK_GENDER)
+                    .jobId(MOCK_JOB.getId())
+                    .yearId(MOCK_JOBYEAR.getId())
                     .build();
 
             // when //then
@@ -164,9 +163,9 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
                     .nickname(" ")
                     .birth(MOCK_BIRTH)
-                    .gender(Gender.FEMALE)
-                    .jobId(1L)
-                    .yearId(1)
+                    .gender(MOCK_GENDER)
+                    .jobId(MOCK_JOB.getId())
+                    .yearId(MOCK_JOBYEAR.getId())
                     .build();
 
             // when // then
@@ -187,9 +186,9 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
                     .nickname("abcdefg!!@12")
                     .birth(MOCK_BIRTH)
-                    .gender(Gender.FEMALE)
-                    .jobId(1L)
-                    .yearId(1)
+                    .gender(MOCK_GENDER)
+                    .jobId(MOCK_JOB.getId())
+                    .yearId(MOCK_JOBYEAR.getId())
                     .build();
 
             // when // then
@@ -210,9 +209,9 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
                     .nickname(MOCK_NICKNAME)
                     .birth(null)
-                    .gender(Gender.FEMALE)
-                    .jobId(1L)
-                    .yearId(1)
+                    .gender(MOCK_GENDER)
+                    .jobId(MOCK_JOB.getId())
+                    .yearId(MOCK_JOBYEAR.getId())
                     .build();
 
             // when // then
@@ -233,9 +232,9 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
                     .nickname(MOCK_NICKNAME)
                     .birth(LocalDate.now())
-                    .gender(Gender.FEMALE)
-                    .jobId(1L)
-                    .yearId(1)
+                    .gender(MOCK_GENDER)
+                    .jobId(MOCK_JOB.getId())
+                    .yearId(MOCK_JOBYEAR.getId())
                     .build();
 
             // when // then
@@ -257,8 +256,8 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .nickname(MOCK_NICKNAME)
                     .birth(MOCK_BIRTH)
                     .gender(null)
-                    .jobId(1L)
-                    .yearId(1)
+                    .jobId(MOCK_JOB.getId())
+                    .yearId(MOCK_JOBYEAR.getId())
                     .build();
 
             // when // then
@@ -279,9 +278,9 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
                     .nickname(MOCK_NICKNAME)
                     .birth(MOCK_BIRTH)
-                    .gender(Gender.FEMALE)
+                    .gender(MOCK_GENDER)
                     .jobId(null)
-                    .yearId(1)
+                    .yearId(MOCK_JOBYEAR.getId())
                     .build();
 
             // when // then
@@ -302,9 +301,9 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
                     .nickname(MOCK_NICKNAME)
                     .birth(MOCK_BIRTH)
-                    .gender(Gender.FEMALE)
+                    .gender(MOCK_GENDER)
                     .jobId(0L)
-                    .yearId(1)
+                    .yearId(MOCK_JOBYEAR.getId())
                     .build();
 
             // when // then
@@ -325,9 +324,9 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
                     .nickname(MOCK_NICKNAME)
                     .birth(MOCK_BIRTH)
-                    .gender(Gender.FEMALE)
+                    .gender(MOCK_GENDER)
                     .jobId(21L)
-                    .yearId(1)
+                    .yearId(MOCK_JOBYEAR.getId())
                     .build();
 
             // when // then
@@ -348,8 +347,8 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
                     .nickname(MOCK_NICKNAME)
                     .birth(MOCK_BIRTH)
-                    .gender(Gender.FEMALE)
-                    .jobId(1L)
+                    .gender(MOCK_GENDER)
+                    .jobId(MOCK_JOB.getId())
                     .yearId(0)
                     .build();
 
@@ -371,8 +370,8 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
                     .nickname(MOCK_NICKNAME)
                     .birth(MOCK_BIRTH)
-                    .gender(Gender.FEMALE)
-                    .jobId(1L)
+                    .gender(MOCK_GENDER)
+                    .jobId(MOCK_JOB.getId())
                     .yearId(5)
                     .build();
 

--- a/src/test/java/com/challenge/api/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/challenge/api/controller/member/MemberControllerTest.java
@@ -3,6 +3,7 @@ package com.challenge.api.controller.member;
 import com.challenge.api.controller.ControllerTestSupport;
 import com.challenge.api.controller.member.request.CheckNicknameRequest;
 import com.challenge.api.service.member.MemberService;
+import com.challenge.api.service.member.response.MemberInfoResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -13,6 +14,7 @@ import org.springframework.http.MediaType;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/com/challenge/api/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/challenge/api/controller/member/MemberControllerTest.java
@@ -1,0 +1,53 @@
+package com.challenge.api.controller.member;
+
+import com.challenge.api.controller.ControllerTestSupport;
+import com.challenge.api.service.member.MemberService;
+import com.challenge.api.service.member.response.MemberInfoResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+public class MemberControllerTest extends ControllerTestSupport {
+
+    @MockBean
+    private MemberService memberService;
+
+    @DisplayName("회원 정보 조회 성공")
+    @Test
+    void getMemberInfoSucceeds() throws Exception {
+        // given
+        // 서비스 mock 처리
+        MemberInfoResponse memberInfoResponse = MemberInfoResponse.builder()
+                .nickname(MOCK_NICKNAME)
+                .birth(MOCK_BIRTH)
+                .gender(MOCK_GENDER)
+                .jobId(MOCK_JOB.getId())
+                .job(MOCK_JOB.getDescription())
+                .jobYearId(MOCK_JOBYEAR.getId())
+                .build();
+        given(memberService.getMemberInfo(any())).willReturn(memberInfoResponse);
+
+        // when // then
+        mockMvc.perform(get("/api/v1/member")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.code").isEmpty())
+                .andExpect(jsonPath("$.url").isEmpty())
+                .andExpect(jsonPath("$.data.nickname").value(MOCK_NICKNAME))
+                .andExpect(jsonPath("$.data.birth").value(MOCK_BIRTH.toString()))
+                .andExpect(jsonPath("$.data.gender").value(MOCK_GENDER.toString()))
+                .andExpect(jsonPath("$.data.jobId").value(MOCK_JOB.getId()))
+                .andExpect(jsonPath("$.data.jobYearId").value(MOCK_JOBYEAR.getId()));
+    }
+
+}

--- a/src/test/java/com/challenge/api/service/auth/AuthServiceTest.java
+++ b/src/test/java/com/challenge/api/service/auth/AuthServiceTest.java
@@ -49,23 +49,25 @@ public class AuthServiceTest {
 
     @Autowired
     private JwtUtil jwtUtil;
-
-    private Job job;
-
+    
+    private static final String MOCK_KAKAO_ACCESS_TOKEN = "test-access-token";
     private static final Long MOCK_SOCIAL_ID = 1L;
     private static final String MOCK_EMAIL = "test@naver.com";
     private static final String MOCK_NICKNAME = "test";
     private static final LocalDate MOCK_BIRTH = LocalDate.of(2000, 1, 1);
-    private static final String MOCK_KAKAO_ACCESS_TOKEN = "test-access-token";
+    protected static final Gender MOCK_GENDER = Gender.MALE;
+    protected static final JobYear MOCK_JOBYEAR = JobYear.LT_1Y;
+    protected Job MOCK_JOB;
+
 
     @BeforeEach
     void setUp() {
         // Job 데이터 저장
-        job = Job.builder()
+        Job job = Job.builder()
                 .code("1")
                 .description("1")
                 .build();
-        job = jobRepository.save(job);
+        MOCK_JOB = jobRepository.save(job);
     }
 
     @DisplayName("카카오 로그인 성공: 토큰과 회원id가 반환된다.")
@@ -121,9 +123,9 @@ public class AuthServiceTest {
                 .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
                 .nickname(MOCK_NICKNAME)
                 .birth(MOCK_BIRTH)
-                .gender(Gender.FEMALE)
-                .jobId(job.getId())
-                .yearId(1)
+                .gender(MOCK_GENDER)
+                .jobId(MOCK_JOB.getId())
+                .yearId(MOCK_JOBYEAR.getId())
                 .build();
 
         // when
@@ -151,9 +153,9 @@ public class AuthServiceTest {
                 .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
                 .nickname(MOCK_NICKNAME)
                 .birth(MOCK_BIRTH)
-                .gender(Gender.FEMALE)
-                .jobId(job.getId())
-                .yearId(1)
+                .gender(MOCK_GENDER)
+                .jobId(MOCK_JOB.getId())
+                .yearId(MOCK_JOBYEAR.getId())
                 .build();
 
         // when // then
@@ -177,9 +179,9 @@ public class AuthServiceTest {
                 .accessToken(MOCK_KAKAO_ACCESS_TOKEN)
                 .nickname(MOCK_NICKNAME) // 동일한 닉네임으로 요청
                 .birth(MOCK_BIRTH)
-                .gender(Gender.FEMALE)
-                .jobId(job.getId())
-                .yearId(1)
+                .gender(MOCK_GENDER)
+                .jobId(MOCK_JOB.getId())
+                .yearId(MOCK_JOBYEAR.getId())
                 .build();
 
         // when // then
@@ -251,9 +253,9 @@ public class AuthServiceTest {
                 .loginType(LoginType.KAKAO)
                 .nickname(MOCK_NICKNAME)
                 .birth(MOCK_BIRTH)
-                .gender(Gender.MALE)
-                .jobYear(JobYear.LT_1Y)
-                .job(job)
+                .gender(MOCK_GENDER)
+                .jobYear(MOCK_JOBYEAR)
+                .job(MOCK_JOB)
                 .build());
     }
 

--- a/src/test/java/com/challenge/api/service/member/MemberServiceTest.java
+++ b/src/test/java/com/challenge/api/service/member/MemberServiceTest.java
@@ -1,0 +1,86 @@
+package com.challenge.api.service.member;
+
+import com.challenge.api.service.member.response.MemberInfoResponse;
+import com.challenge.domain.job.Job;
+import com.challenge.domain.job.JobRepository;
+import com.challenge.domain.member.Gender;
+import com.challenge.domain.member.JobYear;
+import com.challenge.domain.member.LoginType;
+import com.challenge.domain.member.Member;
+import com.challenge.domain.member.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+public class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JobRepository jobRepository;
+
+    private static final Long MOCK_SOCIAL_ID = 1L;
+    private static final String MOCK_EMAIL = "test@naver.com";
+    private static final String MOCK_NICKNAME = "test";
+    private static final LocalDate MOCK_BIRTH = LocalDate.of(2000, 1, 1);
+
+    private Job job;
+
+    @BeforeEach
+    void setUp() {
+        // Job 데이터 저장
+        job = Job.builder()
+                .code("1")
+                .description("1")
+                .build();
+        job = jobRepository.save(job);
+    }
+
+    @DisplayName("회원 정보 조회 성공: 회원 정보가 반환된다.")
+    @Test
+    void getMemberInfoSucceeds() {
+        // given
+        Member member = createMember();
+
+        // when
+        MemberInfoResponse response = memberService.getMemberInfo(member);
+
+        // then
+        assertThat(response.getNickname()).isEqualTo(MOCK_NICKNAME);
+        assertThat(response.getBirth()).isEqualTo(MOCK_BIRTH);
+        assertThat(response.getGender()).isEqualTo(member.getGender());
+        assertThat(response.getJobId()).isEqualTo(job.getId());
+        assertThat(response.getJobYearId()).isEqualTo(member.getJobYear().getId());
+    }
+
+    /*   테스트 공통 메소드   */
+    private Member createMember() {
+        return memberRepository.save(Member.builder()
+                .socialId(MOCK_SOCIAL_ID)
+                .email(MOCK_EMAIL)
+                .loginType(LoginType.KAKAO)
+                .nickname(MOCK_NICKNAME)
+                .birth(MOCK_BIRTH)
+                .gender(Gender.MALE)
+                .jobYear(JobYear.LT_1Y)
+                .job(job)
+                .build());
+    }
+
+}

--- a/src/test/java/com/challenge/api/service/member/MemberServiceTest.java
+++ b/src/test/java/com/challenge/api/service/member/MemberServiceTest.java
@@ -38,13 +38,13 @@ public class MemberServiceTest {
     @Autowired
     private JobRepository jobRepository;
 
-    private static final Long MOCK_SOCIAL_ID = 1L;
-    private static final String MOCK_EMAIL = "test@naver.com";
-    private static final String MOCK_NICKNAME = "test";
-    private static final LocalDate MOCK_BIRTH = LocalDate.of(2000, 1, 1);
-    protected static final Gender MOCK_GENDER = Gender.MALE;
-    protected static final JobYear MOCK_JOBYEAR = JobYear.LT_1Y;
-    protected Job MOCK_JOB;
+    private static final Long MEMBER_SOCIAL_ID = 1L;
+    private static final String MEMBER_EMAIL = "test@naver.com";
+    private static final String MEMBER_NICKNAME = "test";
+    private static final LocalDate MEMBER_BIRTH = LocalDate.of(2000, 1, 1);
+    private static final Gender MEMBER_GENDER = Gender.MALE;
+    private static final JobYear MEMBER_JOBYEAR = JobYear.LT_1Y;
+    private Job MEMBER_JOB;
 
     @BeforeEach
     void setUp() {
@@ -53,7 +53,7 @@ public class MemberServiceTest {
                 .code("1")
                 .description("1")
                 .build();
-        MOCK_JOB = jobRepository.save(job);
+        MEMBER_JOB = jobRepository.save(job);
     }
 
     @DisplayName("닉네임 중복 확인 성공: 닉네임 사용 가능 메시지가 반환된다.")
@@ -80,7 +80,7 @@ public class MemberServiceTest {
 
         // request 값 세팅
         CheckNicknameServiceRequest request = CheckNicknameServiceRequest.builder()
-                .nickname(MOCK_NICKNAME)
+                .nickname(MEMBER_NICKNAME)
                 .build();
 
         // when // then
@@ -99,24 +99,24 @@ public class MemberServiceTest {
         MemberInfoResponse response = memberService.getMemberInfo(member);
 
         // then
-        assertThat(response.getNickname()).isEqualTo(MOCK_NICKNAME);
-        assertThat(response.getBirth()).isEqualTo(MOCK_BIRTH);
-        assertThat(response.getGender()).isEqualTo(MOCK_GENDER);
-        assertThat(response.getJobId()).isEqualTo(MOCK_JOB.getId());
-        assertThat(response.getJobYearId()).isEqualTo(MOCK_JOBYEAR.getId());
+        assertThat(response.getNickname()).isEqualTo(MEMBER_NICKNAME);
+        assertThat(response.getBirth()).isEqualTo(MEMBER_BIRTH);
+        assertThat(response.getGender()).isEqualTo(MEMBER_GENDER);
+        assertThat(response.getJobId()).isEqualTo(MEMBER_JOB.getId());
+        assertThat(response.getJobYearId()).isEqualTo(MEMBER_JOBYEAR.getId());
     }
 
     /*   테스트 공통 메소드   */
     private Member createMember() {
         return memberRepository.save(Member.builder()
-                .socialId(MOCK_SOCIAL_ID)
-                .email(MOCK_EMAIL)
+                .socialId(MEMBER_SOCIAL_ID)
+                .email(MEMBER_EMAIL)
                 .loginType(LoginType.KAKAO)
-                .nickname(MOCK_NICKNAME)
-                .birth(MOCK_BIRTH)
-                .gender(MOCK_GENDER)
-                .jobYear(MOCK_JOBYEAR)
-                .job(MOCK_JOB)
+                .nickname(MEMBER_NICKNAME)
+                .birth(MEMBER_BIRTH)
+                .gender(MEMBER_GENDER)
+                .jobYear(MEMBER_JOBYEAR)
+                .job(MEMBER_JOB)
                 .build());
     }
 

--- a/src/test/java/com/challenge/api/service/member/MemberServiceTest.java
+++ b/src/test/java/com/challenge/api/service/member/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.challenge.api.service.member;
 
 import com.challenge.api.service.member.request.CheckNicknameServiceRequest;
+import com.challenge.api.service.member.response.MemberInfoResponse;
 import com.challenge.domain.job.Job;
 import com.challenge.domain.job.JobRepository;
 import com.challenge.domain.member.Gender;
@@ -41,17 +42,18 @@ public class MemberServiceTest {
     private static final String MOCK_EMAIL = "test@naver.com";
     private static final String MOCK_NICKNAME = "test";
     private static final LocalDate MOCK_BIRTH = LocalDate.of(2000, 1, 1);
-
-    private Job job;
+    protected static final Gender MOCK_GENDER = Gender.MALE;
+    protected static final JobYear MOCK_JOBYEAR = JobYear.LT_1Y;
+    protected Job MOCK_JOB;
 
     @BeforeEach
     void setUp() {
         // Job 데이터 저장
-        job = Job.builder()
+        Job job = Job.builder()
                 .code("1")
                 .description("1")
                 .build();
-        job = jobRepository.save(job);
+        MOCK_JOB = jobRepository.save(job);
     }
 
     @DisplayName("닉네임 중복 확인 성공: 닉네임 사용 가능 메시지가 반환된다.")
@@ -99,9 +101,9 @@ public class MemberServiceTest {
         // then
         assertThat(response.getNickname()).isEqualTo(MOCK_NICKNAME);
         assertThat(response.getBirth()).isEqualTo(MOCK_BIRTH);
-        assertThat(response.getGender()).isEqualTo(member.getGender());
-        assertThat(response.getJobId()).isEqualTo(job.getId());
-        assertThat(response.getJobYearId()).isEqualTo(member.getJobYear().getId());
+        assertThat(response.getGender()).isEqualTo(MOCK_GENDER);
+        assertThat(response.getJobId()).isEqualTo(MOCK_JOB.getId());
+        assertThat(response.getJobYearId()).isEqualTo(MOCK_JOBYEAR.getId());
     }
 
     /*   테스트 공통 메소드   */
@@ -112,9 +114,9 @@ public class MemberServiceTest {
                 .loginType(LoginType.KAKAO)
                 .nickname(MOCK_NICKNAME)
                 .birth(MOCK_BIRTH)
-                .gender(Gender.MALE)
-                .jobYear(JobYear.LT_1Y)
-                .job(job)
+                .gender(MOCK_GENDER)
+                .jobYear(MOCK_JOBYEAR)
+                .job(MOCK_JOB)
                 .build());
     }
 

--- a/src/test/java/com/challenge/domain/member/MemberRepositoryTest.java
+++ b/src/test/java/com/challenge/domain/member/MemberRepositoryTest.java
@@ -1,0 +1,102 @@
+package com.challenge.domain.member;
+
+import com.challenge.domain.job.Job;
+import com.challenge.domain.job.JobRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+public class MemberRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    JobRepository jobRepository;
+
+    private static final Long MEMBER_SOCIAL_ID = 1L;
+    private static final String MEMBER_EMAIL = "test@naver.com";
+    private static final LoginType MEMBER_LOGIN_TYPE = LoginType.KAKAO;
+    private static final String MEMBER_NICKNAME = "test";
+    private static final LocalDate MEMBER_BIRTH = LocalDate.of(2000, 1, 1);
+    private static final Gender MEMBER_GENDER = Gender.MALE;
+    private static final JobYear MEMBER_JOBYEAR = JobYear.LT_1Y;
+
+    private Job MEMBER_JOB;
+
+    @DisplayName("socialId와 loginType으로 회원을 조회한다.")
+    @Test
+    void findBySocialIdAndLoginType() {
+        // given
+        Member member = createMember();
+
+        // when
+        Member resultMember = memberRepository.findBySocialIdAndLoginType(MEMBER_SOCIAL_ID, MEMBER_LOGIN_TYPE);
+
+        // then
+        assertThat(resultMember.getId()).isEqualTo(member.getId());
+        assertThat(resultMember.getSocialId()).isEqualTo(MEMBER_SOCIAL_ID);
+        assertThat(resultMember.getLoginType()).isEqualTo(MEMBER_LOGIN_TYPE);
+    }
+
+    @DisplayName("socialId와 loginType으로 특정 회원의 존재 여부를 조회한다.")
+    @Test
+    void existsBySocialIdAndLoginType() {
+        // given
+        createMember();
+
+        // when
+        boolean exists = memberRepository.existsBySocialIdAndLoginType(MEMBER_SOCIAL_ID, MEMBER_LOGIN_TYPE);
+
+        // then
+        assertTrue(exists);
+    }
+
+    @DisplayName("특정 닉네임을 가진 회원의 존재 여부를 조회한다.")
+    @Test
+    void existsByNickname() {
+        // given
+        createMember();
+
+        // when
+        boolean exists = memberRepository.existsByNickname(MEMBER_NICKNAME);
+
+        // then
+        assertTrue(exists);
+
+    }
+
+    /*  테스트 공통 메소드  */
+    private Job createJob() {
+        MEMBER_JOB = jobRepository.save(Job.builder()
+                .code("1")
+                .description("1")
+                .build());
+        return MEMBER_JOB;
+    }
+
+    private Member createMember() {
+        return memberRepository.save(Member.builder()
+                .socialId(MEMBER_SOCIAL_ID)
+                .email(MEMBER_EMAIL)
+                .loginType(MEMBER_LOGIN_TYPE)
+                .nickname(MEMBER_NICKNAME)
+                .birth(MEMBER_BIRTH)
+                .gender(MEMBER_GENDER)
+                .jobYear(MEMBER_JOBYEAR)
+                .job(MEMBER_JOB)
+                .build());
+    }
+
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
내 회원 정보 조회 API 구현 및 테스트

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 내 회원 정보 조회 API 구현
- 내 회원 정보 조회 API 서비스 테스트코드 추가
- 내 회원 정보 조회 API 컨트롤러 테스트코드 추가
- 테스트 코드에서 mockMember의 성별, 연차, 직무 값도 공통 변수로 추출
- MemberRepository 테스트 코드 작성

## ⏳ 작업 내용
- [x] 내 회원 정보 조회 API 구현
- [x] 내 회원 정보 조회 API 서비스 테스트코드 작성
- [x] 내 회원 정보 조회 API 컨트롤러 테스트코드 작성
- [x] 테스트코드 리팩토링
- [x] MemberRepository 테스트 코드 작성

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
회원 정보 조회 컨트롤러에서 `@AuthMember`로 Member 객체를 받아오게 되어있어서,, memberService에서 회원 정보 조회 메소드가 db 접근을 하지 않고 사실상 response dto 생성만 하고 있습니다..
(지금 서비스 메소드가 아래와 같이 되어 있음)
<img width="498" alt="image" src="https://github.com/user-attachments/assets/43c7a529-4499-4ebd-9d43-0193eaca3f9c">

이 부분을 그래도 서비스 메소드로 유지를 해야할지 아니면 서비스 메소드를 없애고 컨트롤러에서 바로 `MemberInfoResponse.of(member)`를 호출하는게 나은지 모르겠습니다 ㅠㅠ
(컨트롤러에서 바로 호출하는 경우)
<img width="698" alt="image" src="https://github.com/user-attachments/assets/e3285701-2223-44da-8c29-7db7116ca2b3">

