### PR TITLE
[Test] 챌린지 수정 테스트 및 문서화

### DIFF
--- a/src/docs/asciidoc/api/auth.adoc
+++ b/src/docs/asciidoc/api/auth.adoc
@@ -1,123 +1,122 @@
-= 3. 로그인 및 회원가입
+== 3. 로그인 및 회원가입
 
 [[Kakao-Signin-Success]]
-== 3.1. 카카오 소셜 회원가입 성공
-==== HTTP Request
+=== 3.1. 카카오 소셜 회원가입 성공
+.HTTP Request
 include::{snippets}/kakao-signin/kakao-signin-succeeds/http-request.adoc[]
 include::{snippets}/kakao-signin/kakao-signin-succeeds/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/kakao-signin/kakao-signin-succeeds/http-response.adoc[]
 include::{snippets}/kakao-signin/kakao-signin-succeeds/response-fields.adoc[]
 
 [[Kakao-Signin-Fail]]
-== 3.2. 카카오 소셜 회원가입 실패
+=== 3.2. 카카오 소셜 회원가입 실패
 include::{snippets}/kakao-signin/kakao-signin-fail-blank-access-token/response-fields.adoc[]
 
-=== 3.2.1 access token이 공백인 경우
-==== HTTP Request
+==== 3.2.1 access token이 공백인 경우
+.HTTP Request
 include::{snippets}/kakao-signin/kakao-signin-fail-blank-access-token/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/kakao-signin/kakao-signin-fail-blank-access-token/http-response.adoc[]
 
-=== 3.2.2.nickname이 길이/문자 조건을 위반한 경우
-==== HTTP Request
+==== 3.2.2.nickname이 길이/문자 조건을 위반한 경우
+.HTTP Request
 include::{snippets}/kakao-signin/kakao-signin-fail-invalid-nickname/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/kakao-signin/kakao-signin-fail-invalid-nickname/http-response.adoc[]
 
-=== 3.2.3. birth가 null인 경우
-==== HTTP Request
+==== 3.2.3. birth가 null인 경우
+.HTTP Request
 include::{snippets}/kakao-signin/kakao-signin-fail-birth-null/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/kakao-signin/kakao-signin-fail-birth-null/http-response.adoc[]
 
-=== 3.2.4. birth가 미래 날짜인 경우
-==== HTTP Request
+==== 3.2.4. birth가 미래 날짜인 경우
+.HTTP Request
 include::{snippets}/kakao-signin/kakao-signin-fail-birth-not-past/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/kakao-signin/kakao-signin-fail-birth-not-past/http-response.adoc[]
 
-=== 3.2.5. gender가 null인 경우
-==== HTTP Request
+==== 3.2.5. gender가 null인 경우
+.HTTP Request
 include::{snippets}/kakao-signin/kakao-signin-fail-gender-null/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/kakao-signin/kakao-signin-fail-gender-null/http-response.adoc[]
 
-=== 3.2.6. jobId가 null인 경우
-==== HTTP Request
+==== 3.2.6. jobId가 null인 경우
+.HTTP Request
 include::{snippets}/kakao-signin/kakao-signin-fail-job-id-null/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/kakao-signin/kakao-signin-fail-job-id-null/http-response.adoc[]
 
-=== 3.2.7. jobId가 1보다 작은 경우
-==== HTTP Request
+==== 3.2.7. jobId가 1보다 작은 경우
+.HTTP Request
 include::{snippets}/kakao-signin/kakao-signin-fail-job-id-less-than/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/kakao-signin/kakao-signin-fail-job-id-less-than/http-response.adoc[]
 
-=== 3.2.8. jobId가 20보다 큰 경우
-==== HTTP Request
+==== 3.2.8. jobId가 20보다 큰 경우
+.HTTP Request
 include::{snippets}/kakao-signin/kakao-signin-fail-job-id-greater-than/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/kakao-signin/kakao-signin-fail-job-id-greater-than/http-response.adoc[]
 
-=== 3.2.9. yearId가 1보다 작은 경우
-==== HTTP Request
+==== 3.2.9. yearId가 1보다 작은 경우
+.HTTP Request
 include::{snippets}/kakao-signin/kakao-signin-fail-year-id-less-than/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/kakao-signin/kakao-signin-fail-year-id-less-than/http-response.adoc[]
 
-=== 3.2.10. yearId가 4보다 큰 경우
-==== HTTP Request
+==== 3.2.10. yearId가 4보다 큰 경우
+.HTTP Request
 include::{snippets}/kakao-signin/kakao-signin-fail-year-id-more-than/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/kakao-signin/kakao-signin-fail-year-id-more-than/http-response.adoc[]
 
-
 [[Kakao-Login-Success]]
-== 3.3. 카카오 소셜 로그인 성공
-==== HTTP Request
+=== 3.3. 카카오 소셜 로그인 성공
+.HTTP Request
 include::{snippets}/kakao-login/kakao-login-success/http-request.adoc[]
 include::{snippets}/kakao-login/kakao-login-success/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/kakao-login/kakao-login-success/http-response.adoc[]
 include::{snippets}/kakao-login/kakao-login-success/response-fields.adoc[]
 
-== 3.4. 카카오 소셜 로그인 실패
-=== 3.4.1 access token이 공백인 경우
-==== HTTP Request
+=== 3.4. 카카오 소셜 로그인 실패
+==== 3.4.1 access token이 공백인 경우
+.HTTP Request
 include::{snippets}/kakao-login/kakao-login-fail-blank-access-token/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/kakao-login/kakao-login-fail-blank-access-token/http-response.adoc[]
 include::{snippets}/kakao-login/kakao-login-fail-blank-access-token/response-fields.adoc[]
 
-== 3.5. access token 재발급 성공
-==== HTTP Request
+=== 3.5. access token 재발급 성공
+.HTTP Request
 include::{snippets}/reissue-token/reissue-token-success/http-request.adoc[]
 include::{snippets}/reissue-token/reissue-token-success/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/reissue-token/reissue-token-success/http-response.adoc[]
 include::{snippets}/reissue-token/reissue-token-success/response-fields.adoc[]
 
-== 3.6. access token 재발급 실패
-=== 3.6.1. refresh token이 공백인 경우
-==== HTTP Request
+=== 3.6. access token 재발급 실패
+==== 3.6.1. refresh token이 공백인 경우
+.HTTP Request
 include::{snippets}/reissue-token/reissue-token-fail-token-blank/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/reissue-token/reissue-token-fail-token-blank/http-response.adoc[]
 include::{snippets}/reissue-token/reissue-token-fail-token-blank/response-fields.adoc[]

--- a/src/docs/asciidoc/api/category.adoc
+++ b/src/docs/asciidoc/api/category.adoc
@@ -1,11 +1,11 @@
-= 2. 카테고리
+== 2. 카테고리
 
 [[Challenge-Request]]
-== 2.1. 카테고리 목록 조회
+=== 2.1. 카테고리 목록 조회
 
-==== HTTP Request
+.HTTP Request
 include::{snippets}/categories/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/categories/http-response.adoc[]
 include::{snippets}/categories/response-fields.adoc[]

--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -1,35 +1,36 @@
-= 1. 챌린지
+== 1. 챌린지
 
 [[Challenge-Create-Success]]
-== 1.1. 챌린지 생성 성공
+=== 1.1. 챌린지 생성 성공
 
-==== HTTP Request
-include::{snippets}/challenge-create-success/http-request.adoc[]
-include::{snippets}/challenge-create-success/request-fields.adoc[]
+.HTTP Request
+include::{snippets}/create-challenge/create-challenge-success/http-request.adoc[]
+include::{snippets}/create-challenge/create-challenge-success/request-fields.adoc[]
 
-==== HTTP Response
-include::{snippets}/challenge-create-success/http-response.adoc[]
-include::{snippets}/challenge-create-success/response-fields.adoc[]
+.HTTP Response
+include::{snippets}/create-challenge/create-challenge-success/http-response.adoc[]
+include::{snippets}/create-challenge/create-challenge-success/response-fields.adoc[]
 
 [[Challenge-Create-Fail]]
-== 1.2. 챌린지 생성 실패
-=== 1.2.1 제목 누락
+=== 1.2. 챌린지 생성 실패
 
-==== HTTP Request
-include::{snippets}/challenge-create-fail/http-request.adoc[]
-include::{snippets}/challenge-create-fail/request-fields.adoc[]
+==== 1.2.1 제목 누락
+.HTTP Request
+include::{snippets}/create-challenge/create-challenge-fail/http-request.adoc[]
+include::{snippets}/create-challenge/create-challenge-fail/request-fields.adoc[]
 
-==== HTTP Response
-include::{snippets}/challenge-create-fail/http-response.adoc[]
-include::{snippets}/challenge-create-fail/response-fields.adoc[]
+.HTTP Response
+include::{snippets}/create-challenge/create-challenge-fail/http-response.adoc[]
+include::{snippets}/create-challenge/create-challenge-fail/response-fields.adoc[]
 
 [[Challenge-Success]]
-== 1.3. 챌린지 달성 완료
+=== 1.3. 챌린지 달성 완료
 
-==== HTTP Request
-include::{snippets}/challenge-achieve/http-request.adoc[]
-include::{snippets}/challenge-achieve/path-parameters.adoc[]
+.HTTP Request
+include::{snippets}/challenge-controller-docs-test/achieve-challenge/http-request.adoc[]
+include::{snippets}/challenge-controller-docs-test/achieve-challenge/path-parameters.adoc[]
+include::{snippets}/challenge-controller-docs-test/achieve-challenge/request-fields.adoc[]
 
-==== HTTP Response
-include::{snippets}/challenge-achieve/http-response.adoc[]
-include::{snippets}/challenge-achieve/response-fields.adoc[]
+.HTTP Response
+include::{snippets}/challenge-controller-docs-test/achieve-challenge/http-response.adoc[]
+include::{snippets}/challenge-controller-docs-test/achieve-challenge/response-fields.adoc[]

--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -34,3 +34,15 @@ include::{snippets}/challenge-controller-docs-test/achieve-challenge/request-fie
 .HTTP Response
 include::{snippets}/challenge-controller-docs-test/achieve-challenge/http-response.adoc[]
 include::{snippets}/challenge-controller-docs-test/achieve-challenge/response-fields.adoc[]
+
+[[Challenge-Update]]
+=== 1.4. 챌린지 수정 성공
+
+.HTTP Request
+include::{snippets}/challenge-controller-docs-test/update-challenge/http-request.adoc[]
+include::{snippets}/challenge-controller-docs-test/update-challenge/path-parameters.adoc[]
+include::{snippets}/challenge-controller-docs-test/update-challenge/request-fields.adoc[]
+
+.HTTP Response
+include::{snippets}/challenge-controller-docs-test/update-challenge/http-response.adoc[]
+include::{snippets}/challenge-controller-docs-test/update-challenge/response-fields.adoc[]

--- a/src/docs/asciidoc/api/member.adoc
+++ b/src/docs/asciidoc/api/member.adoc
@@ -1,159 +1,159 @@
-= 4. 회원
+== 4. 회원
 
 [[Get-Member-Info-Success]]
-== 4.1. 회원 정보 조회 성공
-==== HTTP Request
+=== 4.1. 회원 정보 조회 성공
+.HTTP Request
 include::{snippets}/member-controller-docs-test/get-member-info-success/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/member-controller-docs-test/get-member-info-success/http-response.adoc[]
 include::{snippets}/member-controller-docs-test/get-member-info-success/response-fields.adoc[]
 
-== 4.2. 닉네임 중복 확인 성공
-==== HTTP Request
+=== 4.2. 닉네임 중복 확인 성공
+.HTTP Request
 include::{snippets}/check-nickname-is-valid/check-nickname-is-valid-success/http-request.adoc[]
 include::{snippets}/check-nickname-is-valid/check-nickname-is-valid-success/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/check-nickname-is-valid/check-nickname-is-valid-success/http-response.adoc[]
 include::{snippets}/check-nickname-is-valid/check-nickname-is-valid-success/response-fields.adoc[]
 
-== 4.3. 닉네임 중복 확인 실패
-=== 4.3.1. 닉네임이 공백인 경우
-==== HTTP Request
+=== 4.3. 닉네임 중복 확인 실패
+==== 4.3.1. 닉네임이 공백인 경우
+.HTTP Request
 include::{snippets}/check-nickname-is-valid/check-nickname-is-valid-failed/http-request.adoc[]
 include::{snippets}/check-nickname-is-valid/check-nickname-is-valid-failed/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/check-nickname-is-valid/check-nickname-is-valid-failed/http-response.adoc[]
 include::{snippets}/check-nickname-is-valid/check-nickname-is-valid-failed/response-fields.adoc[]
 
-== 4.4. 닉네임 수정 성공
-==== HTTP Request
+=== 4.4. 닉네임 수정 성공
+.HTTP Request
 include::{snippets}/update-nickname/update-nickname-success/http-request.adoc[]
 include::{snippets}/update-nickname/update-nickname-success/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/update-nickname/update-nickname-success/http-response.adoc[]
 include::{snippets}/update-nickname/update-nickname-success/response-fields.adoc[]
 
-== 4.5. 닉네임 수정 실패
-=== 4.5.1. 닉네임이 공백인 경우
-==== HTTP Request
+=== 4.5. 닉네임 수정 실패
+==== 4.5.1. 닉네임이 공백인 경우
+.HTTP Request
 include::{snippets}/update-nickname/check-nickname-is-valid-fail/http-request.adoc[]
 include::{snippets}/update-nickname/check-nickname-is-valid-fail/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/update-nickname/check-nickname-is-valid-fail/http-response.adoc[]
 include::{snippets}/update-nickname/check-nickname-is-valid-fail/response-fields.adoc[]
 
-== 4.6. 생년월일 수정 성공
-==== HTTP Request
+=== 4.6. 생년월일 수정 성공
+.HTTP Request
 include::{snippets}/update-birth/update-birth-success/http-request.adoc[]
 include::{snippets}/update-birth/update-birth-success/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/update-birth/update-birth-success/http-response.adoc[]
 include::{snippets}/update-birth/update-birth-success/response-fields.adoc[]
 
-== 4.7. 생년월일 수정 실패
-=== 4.7.1. birth가 미래 날짜인 경우
-==== HTTP Request
+=== 4.7. 생년월일 수정 실패
+==== 4.7.1. birth가 미래 날짜인 경우
+.HTTP Request
 include::{snippets}/update-birth/update-birth-fail/http-request.adoc[]
 include::{snippets}/update-birth/update-birth-fail/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/update-birth/update-birth-fail/http-response.adoc[]
 include::{snippets}/update-birth/update-birth-fail/response-fields.adoc[]
 
-== 4.8. 성별 수정 성공
-==== HTTP Request
+=== 4.8. 성별 수정 성공
+.HTTP Request
 include::{snippets}/update-gender/update-gender-success/http-request.adoc[]
 include::{snippets}/update-gender/update-gender-success/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/update-gender/update-gender-success/http-response.adoc[]
 include::{snippets}/update-gender/update-gender-success/response-fields.adoc[]
 
-== 4.9. 성별 수정 실패
-=== 4.9.1. gender가 null인 경우
-==== HTTP Request
+=== 4.9. 성별 수정 실패
+==== 4.9.1. gender가 null인 경우
+.HTTP Request
 include::{snippets}/update-gender/update-gender-fail/http-request.adoc[]
 include::{snippets}/update-gender/update-gender-fail/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/update-gender/update-gender-fail/http-response.adoc[]
 include::{snippets}/update-gender/update-gender-fail/response-fields.adoc[]
 
-== 4.10. 직무 수정 성공
-==== HTTP Request
+=== 4.10. 직무 수정 성공
+.HTTP Request
 include::{snippets}/update-job/update-job-success/http-request.adoc[]
 include::{snippets}/update-job/update-job-success/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/update-job/update-job-success/http-response.adoc[]
 include::{snippets}/update-job/update-job-success/response-fields.adoc[]
 
-== 4.11. 직무 수정 실패
-=== 4.11.1. jobId가 null인 경우
-==== HTTP Request
+=== 4.11. 직무 수정 실패
+==== 4.11.1. jobId가 null인 경우
+.HTTP Request
 include::{snippets}/update-job/update-job-fail-id-null/http-request.adoc[]
 include::{snippets}/update-job/update-job-fail-id-null/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/update-job/update-job-fail-id-null/http-response.adoc[]
 include::{snippets}/update-job/update-job-fail-id-null/response-fields.adoc[]
 
-=== 4.11.2. jobId가 1보다 작은 경우
-==== HTTP Request
+==== 4.11.2. jobId가 1보다 작은 경우
+.HTTP Request
 include::{snippets}/update-job/update-job-fail-id-less-than/http-request.adoc[]
 include::{snippets}/update-job/update-job-fail-id-less-than/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/update-job/update-job-fail-id-less-than/http-response.adoc[]
 include::{snippets}/update-job/update-job-fail-id-less-than/response-fields.adoc[]
 
-=== 4.11.3. jobId가 20보다 큰 경우
-==== HTTP Request
+==== 4.11.3. jobId가 20보다 큰 경우
+.HTTP Request
 include::{snippets}/update-job/update-job-fail-id-more-than/http-request.adoc[]
 include::{snippets}/update-job/update-job-fail-id-more-than/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/update-job/update-job-fail-id-more-than/http-response.adoc[]
 include::{snippets}/update-job/update-job-fail-id-more-than/response-fields.adoc[]
 
-== 4.12. 연차 수정 성공
-==== HTTP Request
+=== 4.12. 연차 수정 성공
+.HTTP Request
 include::{snippets}/update-job-year/update-job-year-success/http-request.adoc[]
 include::{snippets}/update-job-year/update-job-year-success/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/update-job-year/update-job-year-success/http-response.adoc[]
 include::{snippets}/update-job-year/update-job-year-success/response-fields.adoc[]
 
-== 4.13. 연차 수정 실패
-=== 4.13.1. yearId가 1보다 작은 경우
-==== HTTP Request
+=== 4.13. 연차 수정 실패
+==== 4.13.1. yearId가 1보다 작은 경우
+.HTTP Request
 include::{snippets}/update-job-year/update-job-year-fail-id-less-than/http-request.adoc[]
 include::{snippets}/update-job-year/update-job-year-fail-id-less-than/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/update-job-year/update-job-year-fail-id-less-than/http-response.adoc[]
 include::{snippets}/update-job-year/update-job-year-fail-id-less-than/response-fields.adoc[]
 
-=== 4.13.2. yearId가 4보다 큰 경우
-==== HTTP Request
+==== 4.13.2. yearId가 4보다 큰 경우
+.HTTP Request
 include::{snippets}/update-job-year/update-job-year-fail-id-more-than/http-request.adoc[]
 include::{snippets}/update-job-year/update-job-year-fail-id-more-than/request-fields.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/update-job-year/update-job-year-fail-id-more-than/http-response.adoc[]
 include::{snippets}/update-job-year/update-job-year-fail-id-more-than/response-fields.adoc[]
 
-== 4.14. push 알림 수신 여부 수정 성공
-==== HTTP Request
+=== 4.14. push 알림 수신 여부 수정 성공
+.HTTP Request
 include::{snippets}/update-push-receive/update-push-receive-succeeds/http-request.adoc[]
 
-==== HTTP Response
+.HTTP Response
 include::{snippets}/update-push-receive/update-push-receive-succeeds/http-response.adoc[]
 include::{snippets}/update-push-receive/update-push-receive-succeeds/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -7,7 +7,7 @@ endif::[]
 :icons: font
 :source-highlighter: highlightjs
 :toc: left
-:toclevels: 1
+:toclevels: 2
 :sectlinks:
 
 == Challenge API
@@ -16,5 +16,3 @@ include::api/challenge.adoc[]
 include::api/category.adoc[]
 include::api/auth.adoc[]
 include::api/member.adoc[]
-
-

--- a/src/main/java/com/challenge/api/controller/challenge/ChallengeController.java
+++ b/src/main/java/com/challenge/api/controller/challenge/ChallengeController.java
@@ -2,6 +2,8 @@ package com.challenge.api.controller.challenge;
 
 import com.challenge.annotation.AuthMember;
 import com.challenge.api.ApiResponse;
+import com.challenge.api.controller.challenge.request.ChallengeAchieveRequest;
+import com.challenge.api.controller.challenge.request.ChallengeCancelRequest;
 import com.challenge.api.controller.challenge.request.ChallengeCreateRequest;
 import com.challenge.api.controller.challenge.request.ChallengeUpdateRequest;
 import com.challenge.api.service.challenge.ChallengeService;
@@ -16,7 +18,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
@@ -47,16 +48,16 @@ public class ChallengeController {
     public ApiResponse<ChallengeResponse> achieveChallenge(
             @AuthMember Member member,
             @PathVariable Long challengeId,
-            @RequestParam String achieveDate) {
-        return ApiResponse.ok(challengeService.achieveChallenge(member, challengeId, achieveDate));
+            @RequestBody @Valid ChallengeAchieveRequest request) {
+        return ApiResponse.ok(challengeService.achieveChallenge(member, challengeId, request.toServiceRequest()));
     }
 
     @PostMapping("/challenges/{challengeId}/cancel")
     public ApiResponse<ChallengeResponse> cancelChallenge(
             @AuthMember Member member,
             @PathVariable Long challengeId,
-            @RequestParam String cancelDate) {
-        return ApiResponse.ok(challengeService.cancelChallenge(member, challengeId, cancelDate));
+            @RequestBody @Valid ChallengeCancelRequest request) {
+        return ApiResponse.ok(challengeService.cancelChallenge(member, challengeId, request.toServiceRequest()));
     }
 
     @PutMapping("/challenges/{challengeId}")

--- a/src/main/java/com/challenge/api/controller/challenge/request/ChallengeAchieveRequest.java
+++ b/src/main/java/com/challenge/api/controller/challenge/request/ChallengeAchieveRequest.java
@@ -1,0 +1,21 @@
+package com.challenge.api.controller.challenge.request;
+
+import com.challenge.api.service.challenge.request.ChallengeAchieveServiceRequest;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChallengeAchieveRequest {
+
+    @NotBlank(message = "달성일은 필수 입력 값입니다.")
+    private String achieveDate;
+
+    public ChallengeAchieveServiceRequest toServiceRequest() {
+        return ChallengeAchieveServiceRequest.builder()
+                .achieveDate(achieveDate)
+                .build();
+    }
+
+}

--- a/src/main/java/com/challenge/api/controller/challenge/request/ChallengeCancelRequest.java
+++ b/src/main/java/com/challenge/api/controller/challenge/request/ChallengeCancelRequest.java
@@ -1,0 +1,21 @@
+package com.challenge.api.controller.challenge.request;
+
+import com.challenge.api.service.challenge.request.ChallengeCancelServiceRequest;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChallengeCancelRequest {
+
+    @NotBlank(message = "취소일은 필수 입력 값입니다.")
+    private String cancelDate;
+
+    public ChallengeCancelServiceRequest toServiceRequest() {
+        return ChallengeCancelServiceRequest.builder()
+                .cancelDate(cancelDate)
+                .build();
+    }
+
+}

--- a/src/main/java/com/challenge/api/service/challenge/ChallengeService.java
+++ b/src/main/java/com/challenge/api/service/challenge/ChallengeService.java
@@ -1,5 +1,7 @@
 package com.challenge.api.service.challenge;
 
+import com.challenge.api.service.challenge.request.ChallengeAchieveServiceRequest;
+import com.challenge.api.service.challenge.request.ChallengeCancelServiceRequest;
 import com.challenge.api.service.challenge.request.ChallengeCreateServiceRequest;
 import com.challenge.api.service.challenge.request.ChallengeUpdateServiceRequest;
 import com.challenge.api.service.challenge.response.ChallengeResponse;
@@ -59,15 +61,16 @@ public class ChallengeService {
     }
 
     @Transactional
-    public ChallengeResponse achieveChallenge(Member member, Long challengeId, String achieveDate) {
+    public ChallengeResponse achieveChallenge(Member member, Long challengeId,
+            ChallengeAchieveServiceRequest request) {
         challengeValidator.challengeExistsBy(member, challengeId);
-        DateValidator.isLocalDateFormatter(achieveDate);
-        DateValidator.isBeforeOrEqualToTodayFrom(achieveDate);
+        DateValidator.isLocalDateFormatter(request.getAchieveDate());
+        DateValidator.isBeforeOrEqualToTodayFrom(request.getAchieveDate());
 
         Challenge challenge = challengeRepository.getReferenceById(challengeId);
-        challengeValidator.hasDuplicateRecordFor(challenge, DateUtils.toLocalDate(achieveDate));
+        challengeValidator.hasDuplicateRecordFor(challenge, DateUtils.toLocalDate(request.getAchieveDate()));
 
-        Record record = Record.achieve(challenge, achieveDate);
+        Record record = Record.achieve(challenge, request.getAchieveDate());
         recordRepository.save(record);
         challenge.addRecord(record);
 
@@ -75,14 +78,14 @@ public class ChallengeService {
     }
 
     @Transactional
-    public ChallengeResponse cancelChallenge(Member member, Long challengeId, String cancelDate) {
+    public ChallengeResponse cancelChallenge(Member member, Long challengeId, ChallengeCancelServiceRequest request) {
         challengeValidator.challengeExistsBy(member, challengeId);
-        DateValidator.isLocalDateFormatter(cancelDate);
-        DateValidator.isBeforeOrEqualToTodayFrom(cancelDate);
+        DateValidator.isLocalDateFormatter(request.getCancelDate());
+        DateValidator.isBeforeOrEqualToTodayFrom(request.getCancelDate());
 
         Challenge challenge = challengeRepository.getReferenceById(challengeId);
 
-        Record record = recordValidator.hasRecordFor(challenge, DateUtils.toLocalDate(cancelDate));
+        Record record = recordValidator.hasRecordFor(challenge, DateUtils.toLocalDate(request.getCancelDate()));
         challenge.getRecords().remove(record);
 
         return ChallengeResponse.of(challenge);

--- a/src/main/java/com/challenge/api/service/challenge/request/ChallengeAchieveServiceRequest.java
+++ b/src/main/java/com/challenge/api/service/challenge/request/ChallengeAchieveServiceRequest.java
@@ -1,0 +1,18 @@
+package com.challenge.api.service.challenge.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChallengeAchieveServiceRequest {
+
+    private String achieveDate;
+
+    @Builder
+    private ChallengeAchieveServiceRequest(String achieveDate) {
+        this.achieveDate = achieveDate;
+    }
+
+}

--- a/src/main/java/com/challenge/api/service/challenge/request/ChallengeCancelServiceRequest.java
+++ b/src/main/java/com/challenge/api/service/challenge/request/ChallengeCancelServiceRequest.java
@@ -1,0 +1,18 @@
+package com.challenge.api.service.challenge.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChallengeCancelServiceRequest {
+
+    private String cancelDate;
+
+    @Builder
+    private ChallengeCancelServiceRequest(String cancelDate) {
+        this.cancelDate = cancelDate;
+    }
+
+}

--- a/src/main/java/com/challenge/api/validator/ChallengeValidator.java
+++ b/src/main/java/com/challenge/api/validator/ChallengeValidator.java
@@ -34,9 +34,4 @@ public class ChallengeValidator {
         }
     }
 
-    public Challenge findById(Long challengeId) {
-        return challengeRepository.findById(challengeId)
-                .orElseThrow(() -> new GlobalException(ErrorCode.CHALLENGE_NOT_FOUND));
-    }
-
 }

--- a/src/main/java/com/challenge/exception/ApiControllerAdvice.java
+++ b/src/main/java/com/challenge/exception/ApiControllerAdvice.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -29,22 +30,42 @@ public class ApiControllerAdvice {
                 .code(ex.getCode())
                 .message(ex.getMessage())
                 .url(request.getRequestURI())
+                .data(null)
                 .build();
 
         return new ResponseEntity<>(errorResponse, HttpStatusCode.valueOf(ex.getStatus().value()));
     }
 
     /**
-     * @Valid 입력 데이터의 유효성 검사 실패 시 발생하는 예외 처리 ( 컨트롤러 DTO )
+     * 입력 데이터의 유효성 검사 실패 시 발생하는 예외 처리 ( 컨트롤러 DTO )
      */
     @ExceptionHandler
-    public ResponseEntity<ApiResponse<Object>> methodArgumentNotValidException(MethodArgumentNotValidException e,
+    public ResponseEntity<ApiResponse<Object>> methodArgumentNotValidException(
+            MethodArgumentNotValidException e,
             HttpServletRequest request) {
         ApiResponse<Object> errorResponse = ApiResponse
                 .builder()
                 .status(BAD_REQUEST)
                 .message(e.getBindingResult().getAllErrors().get(0).getDefaultMessage())
                 .code("VALID_ERROR")
+                .url(request.getRequestURI())
+                .data(null)
+                .build();
+
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    /**
+     * RequestParam 누락 시 발생하는 예외 처리
+     */
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<Object>> missingServletRequestParameterException(
+            MissingServletRequestParameterException ex,
+            HttpServletRequest request) {
+        ApiResponse<Object> errorResponse = ApiResponse.builder()
+                .status(BAD_REQUEST)
+                .message("필수 요청 파라미터인 '(%s)'가 존재하지 않습니다.".formatted(ex.getParameterName()))
+                .code("MISSING_PARAMETER")
                 .url(request.getRequestURI())
                 .data(null)
                 .build();

--- a/src/main/java/com/challenge/exception/ApiControllerAdvice.java
+++ b/src/main/java/com/challenge/exception/ApiControllerAdvice.java
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -48,24 +47,6 @@ public class ApiControllerAdvice {
                 .status(BAD_REQUEST)
                 .message(e.getBindingResult().getAllErrors().get(0).getDefaultMessage())
                 .code("VALID_ERROR")
-                .url(request.getRequestURI())
-                .data(null)
-                .build();
-
-        return ResponseEntity.badRequest().body(errorResponse);
-    }
-
-    /**
-     * RequestParam 누락 시 발생하는 예외 처리
-     */
-    @ExceptionHandler
-    public ResponseEntity<ApiResponse<Object>> missingServletRequestParameterException(
-            MissingServletRequestParameterException ex,
-            HttpServletRequest request) {
-        ApiResponse<Object> errorResponse = ApiResponse.builder()
-                .status(BAD_REQUEST)
-                .message("필수 요청 파라미터인 '(%s)'가 존재하지 않습니다.".formatted(ex.getParameterName()))
-                .code("MISSING_PARAMETER")
                 .url(request.getRequestURI())
                 .data(null)
                 .build();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,7 +63,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: false
   datasource:
     url: jdbc:mysql://${RDS_PRIVATE_IP}:${RDS_PORT}/${DB_SCHEMA_NAME}?useSSL=true

--- a/src/test/java/com/challenge/api/controller/ControllerTestSupport.java
+++ b/src/test/java/com/challenge/api/controller/ControllerTestSupport.java
@@ -56,7 +56,6 @@ public abstract class ControllerTestSupport {
         given(authInterceptor.preHandle(any(), any(), any())).willReturn(true);
 
         // 리졸버가 mockMember를 반환하도록 Mock 설정
-
         mockMember = Member.builder()
                 .socialId(MOCK_SOCIAL_ID)
                 .email(MOCK_EMAIL)

--- a/src/test/java/com/challenge/api/controller/challenge/ChallengeControllerTest.java
+++ b/src/test/java/com/challenge/api/controller/challenge/ChallengeControllerTest.java
@@ -2,14 +2,19 @@ package com.challenge.api.controller.challenge;
 
 import com.challenge.api.controller.ControllerTestSupport;
 import com.challenge.api.service.challenge.ChallengeService;
+import com.challenge.api.service.challenge.request.ChallengeAchieveServiceRequest;
+import com.challenge.api.service.challenge.request.ChallengeCancelServiceRequest;
 import com.challenge.api.service.challenge.request.ChallengeCreateServiceRequest;
+import com.challenge.api.service.challenge.request.ChallengeUpdateServiceRequest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -20,289 +25,403 @@ class ChallengeControllerTest extends ControllerTestSupport {
     @MockitoBean
     private ChallengeService challengeService;
 
+    @Nested
     @DisplayName("챌린지를 생성한다.")
-    @Test
-    void createChallenge() throws Exception {
-        // given
-        ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
-                .builder()
-                .title("챌린지 제목")
-                .durationInWeeks(1)
-                .weeklyGoalCount(2)
-                .categoryId(1L)
-                .color("색상")
-                .content("내용")
-                .build();
+    class CreateChallenge {
 
-        // when // then
-        mockMvc.perform(
-                        post("/api/v1/challenges")
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("OK"))
-                .andExpect(jsonPath("$.code").isEmpty())
-                .andExpect(jsonPath("$.url").isEmpty());
+        @DisplayName("챌린지를 성공적으로 생성한다.")
+        @Test
+        void createChallenge() throws Exception {
+            // given
+            ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
+                    .builder()
+                    .title("챌린지 제목")
+                    .durationInWeeks(1)
+                    .weeklyGoalCount(2)
+                    .categoryId(1L)
+                    .color("색상")
+                    .content("내용")
+                    .build();
+
+            // when // then
+            mockMvc.perform(
+                            post("/api/v1/challenges")
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("OK"))
+                    .andExpect(jsonPath("$.code").isEmpty())
+                    .andExpect(jsonPath("$.url").isEmpty());
+        }
+
+        @DisplayName("챌린지를 생성할 때 제목은 필수 입력값이다.")
+        @Test
+        void createChallenge_Fail_TitleBlank() throws Exception {
+            // given
+            ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
+                    .builder()
+                    .title("") // 제목 빈 값
+                    .durationInWeeks(1)
+                    .weeklyGoalCount(2)
+                    .categoryId(1L)
+                    .color("색상")
+                    .content("내용")
+                    .build();
+
+            // when // then
+            mockMvc.perform(
+                            post("/api/v1/challenges")
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("제목은 필수 입력값입니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+
+        @DisplayName("챌린지를 생성할 때 제목은 공백 포함 30자 이하여야 한다.")
+        @Test
+        void createChallenge_Fail_TitleSizeMax() throws Exception {
+            // given
+            String title = "a".repeat(31);
+            ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
+                    .builder()
+                    .title(title)
+                    .durationInWeeks(1)
+                    .weeklyGoalCount(2)
+                    .categoryId(1L)
+                    .color("색상")
+                    .content("내용")
+                    .build();
+
+            // when // then
+            mockMvc.perform(
+                            post("/api/v1/challenges")
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("제목은 공백 포함 30자 이하여야 합니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+
+        @DisplayName("챌린지를 생성할 때 챌린지 기간은 최소 1주 이상이어야 한다.")
+        @Test
+        void createChallenge_Fail_DurationMin() throws Exception {
+            // given
+            ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
+                    .builder()
+                    .title("챌린지 제목")
+                    .durationInWeeks(0) // 1주 미만
+                    .weeklyGoalCount(2)
+                    .categoryId(1L)
+                    .color("색상")
+                    .content("내용")
+                    .build();
+
+            // when // then
+            mockMvc.perform(
+                            post("/api/v1/challenges")
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("챌린지 기간은 최소 1주 이상이어야 합니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+
+        @DisplayName("챌린지를 생성할 때 챌린지 기간은 최대 4주 이하여야 한다.")
+        @Test
+        void createChallenge_Fail_DurationMax() throws Exception {
+            // given
+            ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
+                    .builder()
+                    .title("챌린지 제목")
+                    .durationInWeeks(5) // 4주 초과
+                    .weeklyGoalCount(2)
+                    .categoryId(1L)
+                    .color("색상")
+                    .content("내용")
+                    .build();
+
+            // when // then
+            mockMvc.perform(
+                            post("/api/v1/challenges")
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("챌린지 기간은 최대 4주 이하여야 합니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+
+        @DisplayName("챌린지를 생성할 때 주간 목표 횟수는 최소 1회 이상이어야 한다.")
+        @Test
+        void createChallenge_Fail_WeeklyGoalCountMin() throws Exception {
+            // given
+            ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
+                    .builder()
+                    .title("챌린지 제목")
+                    .durationInWeeks(3)
+                    .weeklyGoalCount(0) // 1회 미만
+                    .categoryId(1L)
+                    .color("색상")
+                    .content("내용")
+                    .build();
+
+            // when // then
+            mockMvc.perform(
+                            post("/api/v1/challenges")
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("주간 목표 횟수는 최소 1회 이상이어야 합니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+
+        @DisplayName("챌린지를 생성할 때 주간 목표 횟수는 최대 7회 이하여야 한다.")
+        @Test
+        void createChallenge_Fail_WeekGoalCountMax() throws Exception {
+            // given
+            ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
+                    .builder()
+                    .title("챌린지 제목")
+                    .durationInWeeks(3)
+                    .weeklyGoalCount(8) // 7회 초과
+                    .categoryId(1L)
+                    .color("색상")
+                    .content("내용")
+                    .build();
+
+            // when // then
+            mockMvc.perform(
+                            post("/api/v1/challenges")
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("주간 목표 횟수는 최대 7회 이하여야 합니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+
+        @DisplayName("챌린지를 생성할 때 카테고리는 필수 입력값이다.")
+        @Test
+        void createChallenge_Fail_CategoryNull() throws Exception {
+            // given
+            ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
+                    .builder()
+                    .title("챌린지 제목")
+                    .durationInWeeks(1)
+                    .weeklyGoalCount(2)
+                    .categoryId(null) // 카테고리 누락
+                    .color("색상")
+                    .content("내용")
+                    .build();
+
+            // when // then
+            mockMvc.perform(
+                            post("/api/v1/challenges")
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("카테고리는 필수 입력값입니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+
+        @DisplayName("챌린지를 생성할 때 색상은 필수 입력값이다.")
+        @Test
+        void createChallenge_Fail_ColorBlank() throws Exception {
+            // given
+            ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
+                    .builder()
+                    .title("챌린지 제목")
+                    .durationInWeeks(1)
+                    .weeklyGoalCount(2)
+                    .categoryId(1L)
+                    .color("")
+                    .content("내용")
+                    .build();
+
+            // when // then
+            mockMvc.perform(
+                            post("/api/v1/challenges")
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("색상은 필수 입력값입니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+
+        @DisplayName("챌린지를 생성할 때 상세 내용은 공백 포함 최대 500자 이하여야 한다.")
+        void createChallenge_Fail_ContentSizeMax() throws Exception {
+            // given
+            String content = "a".repeat(501);
+            ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
+                    .builder()
+                    .title("챌린지 제목")
+                    .durationInWeeks(1)
+                    .weeklyGoalCount(2)
+                    .categoryId(1L)
+                    .color("색상")
+                    .content(content)
+                    .build();
+
+            // when // then
+            mockMvc.perform(
+                            post("/api/v1/challenges")
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("상세 내용은 공백 포함 최대 500자 이하여야 합니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+
     }
 
-    @DisplayName("챌린지를 생성할 때 제목은 필수 입력값이다.")
-    @Test
-    void createChallenge_Fail_TitleBlank() throws Exception {
-        // given
-        ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
-                .builder()
-                .title("") // 제목 빈 값
-                .durationInWeeks(1)
-                .weeklyGoalCount(2)
-                .categoryId(1L)
-                .color("색상")
-                .content("내용")
-                .build();
+    @Nested
+    @DisplayName("챌린지를 달성한다")
+    class AchieveChallenge {
 
-        // when // then
-        mockMvc.perform(
-                        post("/api/v1/challenges")
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("제목은 필수 입력값입니다."))
-                .andExpect(jsonPath("$.code").value("VALID_ERROR"))
-                .andExpect(jsonPath("$.data").isEmpty());
+        @DisplayName("챌린지를 성공적으로 달성한다.")
+        @Test
+        void achieveChallenge() throws Exception {
+            // given
+            Long challengeId = 1L;
+            String achieveDate = "2024-11-11";
+            ChallengeAchieveServiceRequest achieveRequest = ChallengeAchieveServiceRequest.builder()
+                    .achieveDate(achieveDate)
+                    .build();
+
+            // when // then
+            mockMvc.perform(
+                            post("/api/v1/challenges/{challengeId}/achieve", challengeId)
+                                    .content(objectMapper.writeValueAsString(achieveRequest))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("OK"))
+                    .andExpect(jsonPath("$.code").isEmpty())
+                    .andExpect(jsonPath("$.url").isEmpty());
+        }
+
+        @DisplayName("챌린지를 달성할 때 달성일은 필수 입력값이다.")
+        @Test
+        void achieveChallenge_Fail_achieveDateBlank() throws Exception {
+            // given
+            Long challengeId = 1L;
+            ChallengeAchieveServiceRequest request = ChallengeAchieveServiceRequest.builder()
+                    .achieveDate("") // 달성일 누락
+                    .build();
+
+            // when // then
+            mockMvc.perform(
+                            post("/api/v1/challenges/{challengeId}/achieve", challengeId)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("달성일은 필수 입력 값입니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+
     }
 
-    @DisplayName("챌린지를 생성할 때 제목은 공백 포함 30자 이하여야 한다.")
-    @Test
-    void createChallenge_Fail_TitleSizeMax() throws Exception {
-        // given
-        String title = "a".repeat(31);
-        ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
-                .builder()
-                .title(title)
-                .durationInWeeks(1)
-                .weeklyGoalCount(2)
-                .categoryId(1L)
-                .color("색상")
-                .content("내용")
-                .build();
+    @Nested
+    @DisplayName("챌린지를 취소한다.")
+    class CancelChallenge {
 
-        // when // then
-        mockMvc.perform(
-                        post("/api/v1/challenges")
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("제목은 공백 포함 30자 이하여야 합니다."))
-                .andExpect(jsonPath("$.code").value("VALID_ERROR"))
-                .andExpect(jsonPath("$.data").isEmpty());
+        @DisplayName("챌린지를 성공적으로 취소한다.")
+        @Test
+        void cancelChallenge() throws Exception {
+            // given
+            Long challengeId = 1L;
+            String cancelDate = "2024-11-11";
+            ChallengeCancelServiceRequest cancelRequest = ChallengeCancelServiceRequest.builder()
+                    .cancelDate(cancelDate)
+                    .build();
+
+            // when // then
+            mockMvc.perform(
+                            post("/api/v1/challenges/{challengeId}/cancel", challengeId)
+                                    .content(objectMapper.writeValueAsString(cancelRequest))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("OK"))
+                    .andExpect(jsonPath("$.code").isEmpty())
+                    .andExpect(jsonPath("$.url").isEmpty());
+        }
+
+        @DisplayName("챌린지를 취소할 때 취소일은 필수 입력값이다.")
+        @Test
+        void cancelChallenge_Fail_cancelDateBlank() throws Exception {
+            // given
+            Long challengeId = 1L;
+
+            ChallengeCancelServiceRequest request = ChallengeCancelServiceRequest.builder()
+                    .cancelDate("") // 취소일 누락
+                    .build();
+
+            // when // then
+            mockMvc.perform(
+                            post("/api/v1/challenges/{challengeId}/cancel", challengeId)
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("취소일은 필수 입력 값입니다."))
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+
     }
 
-    @DisplayName("챌린지를 생성할 때 챌린지 기간은 최소 1주 이상이어야 한다.")
+    @DisplayName("챌린지를 성공적으로 수정한다.")
     @Test
-    void createChallenge_Fail_DurationMin() throws Exception {
-        // given
-        ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
-                .builder()
-                .title("챌린지 제목")
-                .durationInWeeks(0) // 1주 미만
-                .weeklyGoalCount(2)
-                .categoryId(1L)
-                .color("색상")
-                .content("내용")
-                .build();
-
-        // when // then
-        mockMvc.perform(
-                        post("/api/v1/challenges")
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("챌린지 기간은 최소 1주 이상이어야 합니다."))
-                .andExpect(jsonPath("$.code").value("VALID_ERROR"))
-                .andExpect(jsonPath("$.data").isEmpty());
-    }
-
-    @DisplayName("챌린지를 생성할 때 챌린지 기간은 최대 4주 이하여야 한다.")
-    @Test
-    void createChallenge_Fail_DurationMax() throws Exception {
-        // given
-        ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
-                .builder()
-                .title("챌린지 제목")
-                .durationInWeeks(5) // 4주 초과
-                .weeklyGoalCount(2)
-                .categoryId(1L)
-                .color("색상")
-                .content("내용")
-                .build();
-
-        // when // then
-        mockMvc.perform(
-                        post("/api/v1/challenges")
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("챌린지 기간은 최대 4주 이하여야 합니다."))
-                .andExpect(jsonPath("$.code").value("VALID_ERROR"))
-                .andExpect(jsonPath("$.data").isEmpty());
-    }
-
-    @DisplayName("챌린지를 생성할 때 주간 목표 횟수는 최소 1회 이상이어야 한다.")
-    @Test
-    void createChallenge_Fail_WeeklyGoalCountMin() throws Exception {
-        // given
-        ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
-                .builder()
-                .title("챌린지 제목")
-                .durationInWeeks(3)
-                .weeklyGoalCount(0) // 1회 미만
-                .categoryId(1L)
-                .color("색상")
-                .content("내용")
-                .build();
-
-        // when // then
-        mockMvc.perform(
-                        post("/api/v1/challenges")
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("주간 목표 횟수는 최소 1회 이상이어야 합니다."))
-                .andExpect(jsonPath("$.code").value("VALID_ERROR"))
-                .andExpect(jsonPath("$.data").isEmpty());
-    }
-
-    @DisplayName("챌린지를 생성할 때 주간 목표 횟수는 최대 7회 이하여야 한다.")
-    @Test
-    void createChallenge_Fail_WeekGoalCountMax() throws Exception {
-        // given
-        ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
-                .builder()
-                .title("챌린지 제목")
-                .durationInWeeks(3)
-                .weeklyGoalCount(8) // 7회 초과
-                .categoryId(1L)
-                .color("색상")
-                .content("내용")
-                .build();
-
-        // when // then
-        mockMvc.perform(
-                        post("/api/v1/challenges")
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("주간 목표 횟수는 최대 7회 이하여야 합니다."))
-                .andExpect(jsonPath("$.code").value("VALID_ERROR"))
-                .andExpect(jsonPath("$.data").isEmpty());
-    }
-
-    @DisplayName("챌린지를 생성할 때 카테고리는 필수 입력값이다.")
-    @Test
-    void createChallenge_Fail_CategoryNull() throws Exception {
-        // given
-        ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
-                .builder()
-                .title("챌린지 제목")
-                .durationInWeeks(1)
-                .weeklyGoalCount(2)
-                .categoryId(null) // 카테고리 누락
-                .color("색상")
-                .content("내용")
-                .build();
-
-        // when // then
-        mockMvc.perform(
-                        post("/api/v1/challenges")
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("카테고리는 필수 입력값입니다."))
-                .andExpect(jsonPath("$.code").value("VALID_ERROR"))
-                .andExpect(jsonPath("$.data").isEmpty());
-    }
-
-    @DisplayName("챌린지를 생성할 때 색상은 필수 입력값이다.")
-    @Test
-    void createChallenge_Fail_ColorBlank() throws Exception {
-        // given
-        ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
-                .builder()
-                .title("챌린지 제목")
-                .durationInWeeks(1)
-                .weeklyGoalCount(2)
-                .categoryId(1L)
-                .color("")
-                .content("내용")
-                .build();
-
-        // when // then
-        mockMvc.perform(
-                        post("/api/v1/challenges")
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("색상은 필수 입력값입니다."))
-                .andExpect(jsonPath("$.code").value("VALID_ERROR"))
-                .andExpect(jsonPath("$.data").isEmpty());
-    }
-
-    @DisplayName("챌린지를 생성할 때 상세 내용은 공백 포함 최대 500자 이하여야 한다.")
-    void createChallenge_Fail_ContentSizeMax() throws Exception {
-        // given
-        String content = "a".repeat(501);
-        ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
-                .builder()
-                .title("챌린지 제목")
-                .durationInWeeks(1)
-                .weeklyGoalCount(2)
-                .categoryId(1L)
-                .color("색상")
-                .content(content)
-                .build();
-
-        // when // then
-        mockMvc.perform(
-                        post("/api/v1/challenges")
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("상세 내용은 공백 포함 최대 500자 이하여야 합니다."))
-                .andExpect(jsonPath("$.code").value("VALID_ERROR"))
-                .andExpect(jsonPath("$.data").isEmpty());
-    }
-
-    @DisplayName("챌린지를 달성한다.")
-    @Test
-    void successChallenge() throws Exception {
+    void updateChallenge() throws Exception {
         // given
         Long challengeId = 1L;
-        String achieveDate = "2024-11-11";
+        ChallengeUpdateServiceRequest request = ChallengeUpdateServiceRequest.builder()
+                .title("챌린지 제목")
+                .categoryId(1L)
+                .color("색상")
+                .content("내용")
+                .build();
 
         // when // then
         mockMvc.perform(
-                        post("/api/v1/challenges/{challengeId}/achieve", challengeId)
+                        put("/api/v1/challenges/{challengeId}", challengeId)
+                                .content(objectMapper.writeValueAsString(request))
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .param("achieveDate", achieveDate)
                 )
                 .andDo(print())
                 .andExpect(status().isOk())

--- a/src/test/java/com/challenge/api/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/challenge/api/controller/member/MemberControllerTest.java
@@ -490,8 +490,6 @@ class MemberControllerTest extends ControllerTestSupport {
                     .andExpect(jsonPath("$.code").value(ErrorCode.S3_UPLOAD_ERROR.getCode()))
                     .andExpect(jsonPath("$.url").value("/api/v1/member/profile/img"))
                     .andExpect(jsonPath("$.data").isEmpty());
-
-
         }
 
     }

--- a/src/test/java/com/challenge/api/validator/ChallengeValidatorTest.java
+++ b/src/test/java/com/challenge/api/validator/ChallengeValidatorTest.java
@@ -60,7 +60,7 @@ class ChallengeValidatorTest {
 
     @DisplayName("존재하지 않는 챌린지 ID로 조회하는 경우 예외가 발생한다.")
     @Test
-    void challengeId() {
+    void challengeExists() {
         // given
         Member member = createMember("nickname");
         Member savedMember = memberRepository.save(member);

--- a/src/test/java/com/challenge/docs/AuthControllerDocsTest.java
+++ b/src/test/java/com/challenge/docs/AuthControllerDocsTest.java
@@ -65,15 +65,15 @@ class AuthControllerDocsTest extends RestDocsSupport {
             return new FieldDescriptor[]{
                     fieldWithPath("accessToken").type(STRING).description("카카오 access token"),
                     fieldWithPath("nickname").type(STRING).description("회원 닉네임")
-                            .attributes(field("4~10자, 특수문자 및 공백 불가")),
+                            .attributes(field("constraints", "4~10자, 특수문자 및 공백 불가")),
                     fieldWithPath("birth").type(STRING).description("생일")
-                            .attributes(field("과거 날짜, yyyy-MM-dd")),
+                            .attributes(field("constraints", "과거 날짜, yyyy-MM-dd")),
                     fieldWithPath("gender").type(STRING).description("성별")
-                            .attributes(field("MALE, FEMALE")),
+                            .attributes(field("constraints", "MALE, FEMALE")),
                     fieldWithPath("jobId").type(NUMBER).description("직무 id")
-                            .attributes(field("1~20 사이의 숫자")),
+                            .attributes(field("constraints", "1~20 사이의 숫자")),
                     fieldWithPath("yearId").type(NUMBER).description("연차 id")
-                            .attributes(field("1~4 사이의 숫자"))
+                            .attributes(field("constraints", "1~4 사이의 숫자"))
             };
         }
 
@@ -237,15 +237,15 @@ class AuthControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("accessToken").type(STRING).description("카카오 access token"),
                                     fieldWithPath("nickname").type(STRING).description("회원 닉네임")
-                                            .attributes(field("4~10자, 특수문자 및 공백 불가")),
+                                            .attributes(field("constraints", "4~10자, 특수문자 및 공백 불가")),
                                     fieldWithPath("birth").type(NULL).description("생일")
-                                            .attributes(field("과거 날짜")),
+                                            .attributes(field("constraints", "과거 날짜")),
                                     fieldWithPath("gender").type(STRING).description("성별")
-                                            .attributes(field("MALE, FEMALE")),
+                                            .attributes(field("constraints", "MALE, FEMALE")),
                                     fieldWithPath("jobId").type(NUMBER).description("직무 id")
-                                            .attributes(field("1~20 사이의 숫자")),
+                                            .attributes(field("constraints", "1~20 사이의 숫자")),
                                     fieldWithPath("yearId").type(NUMBER).description("연차 id")
-                                            .attributes(field("1~4 사이의 숫자"))),
+                                            .attributes(field("constraints", "1~4 사이의 숫자"))),
                             responseFields(failResponse())
                     ));
         }
@@ -302,15 +302,15 @@ class AuthControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("accessToken").type(STRING).description("카카오 access token"),
                                     fieldWithPath("nickname").type(STRING).description("회원 닉네임")
-                                            .attributes(field("4~10자, 특수문자 및 공백 불가")),
+                                            .attributes(field("constraints", "4~10자, 특수문자 및 공백 불가")),
                                     fieldWithPath("birth").type(STRING).description("생일")
-                                            .attributes(field("과거 날짜")),
+                                            .attributes(field("constraints", "과거 날짜")),
                                     fieldWithPath("gender").type(NULL).description("성별")
-                                            .attributes(field("MALE, FEMALE")),
+                                            .attributes(field("constraints", "MALE, FEMALE")),
                                     fieldWithPath("jobId").type(NUMBER).description("직무 id")
-                                            .attributes(field("1~20 사이의 숫자")),
+                                            .attributes(field("constraints", "1~20 사이의 숫자")),
                                     fieldWithPath("yearId").type(NUMBER).description("연차 id")
-                                            .attributes(field("1~4 사이의 숫자"))
+                                            .attributes(field("constraints", "1~4 사이의 숫자"))
                             ),
                             responseFields(failResponse())
                     ));
@@ -341,15 +341,15 @@ class AuthControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("accessToken").type(STRING).description("카카오 access token"),
                                     fieldWithPath("nickname").type(STRING).description("회원 닉네임")
-                                            .attributes(field("4~10자, 특수문자 및 공백 불가")),
+                                            .attributes(field("constraints", "4~10자, 특수문자 및 공백 불가")),
                                     fieldWithPath("birth").type(STRING).description("생일")
-                                            .attributes(field("과거 날짜")),
+                                            .attributes(field("constraints", "과거 날짜")),
                                     fieldWithPath("gender").type(STRING).description("성별")
-                                            .attributes(field("MALE, FEMALE")),
+                                            .attributes(field("constraints", "MALE, FEMALE")),
                                     fieldWithPath("jobId").type(NULL).description("직무 id")
-                                            .attributes(field("1~20 사이의 숫자")),
+                                            .attributes(field("constraints", "1~20 사이의 숫자")),
                                     fieldWithPath("yearId").type(NUMBER).description("연차 id")
-                                            .attributes(field("1~4 사이의 숫자"))
+                                            .attributes(field("constraints", "1~4 사이의 숫자"))
                             ),
                             responseFields(failResponse())
                     ));

--- a/src/test/java/com/challenge/docs/ChallengeControllerDocsTest.java
+++ b/src/test/java/com/challenge/docs/ChallengeControllerDocsTest.java
@@ -6,6 +6,7 @@ import com.challenge.api.service.challenge.ChallengeService;
 import com.challenge.api.service.challenge.request.ChallengeAchieveServiceRequest;
 import com.challenge.api.service.challenge.request.ChallengeCancelServiceRequest;
 import com.challenge.api.service.challenge.request.ChallengeCreateServiceRequest;
+import com.challenge.api.service.challenge.request.ChallengeUpdateServiceRequest;
 import com.challenge.api.service.challenge.response.ChallengeResponse;
 import com.challenge.api.service.record.response.RecordResponse;
 import com.challenge.domain.member.Member;
@@ -34,6 +35,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -371,10 +373,102 @@ class ChallengeControllerDocsTest extends RestDocsSupport {
     @Test
     void updateChallenge() throws Exception {
         // given
+        Long challengeId = 1L;
+        ChallengeUpdateServiceRequest request = ChallengeUpdateServiceRequest.builder()
+                .title("수정된 챌린지 제목")
+                .categoryId(1L)
+                .color("수정된 색상")
+                .content("수정된 내용")
+                .build();
 
-        // when
+        given(challengeService.updateChallenge(
+                any(Member.class),
+                any(Long.class),
+                any(ChallengeUpdateServiceRequest.class)
+        )).willReturn(ChallengeResponse
+                .builder()
+                .id(1L)
+                .category(CategoryResponse.builder()
+                        .id(1L)
+                        .name("카테고리 이름")
+                        .build())
+                .record(RecordResponse.builder()
+                        .successDates(
+                                List.of(
+                                        DateUtils.toDayString(LocalDate.now()),
+                                        DateUtils.toDayString(LocalDate.now().plusDays(1))
+                                )
+                        )
+                        .build())
+                .title("수정된 챌린지 제목")
+                .content("수정된 챌린지 내용")
+                .durationInWeeks(2)
+                .weekGoalCount(2)
+                .totalGoalCount(4)
+                .color("수정된 색상")
+                .startDateTime(DateUtils.toDateTimeString(LocalDateTime.now()))
+                .endDateTime(DateUtils.toDateTimeString(LocalDateTime.now().plusWeeks(2)))
+                .build());
 
-        // then
+        // when // then
+        mockMvc.perform(
+                        put("/api/v1/challenges/{challengeId}", challengeId)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        pathParameters(
+                                parameterWithName("challengeId")
+                                        .attributes(field("type", "Long"))
+                                        .description("챌린지 아이디")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").type(STRING)
+                                        .description("챌린지 제목"),
+                                fieldWithPath("categoryId").type(NUMBER)
+                                        .description("카테고리 아이디"),
+                                fieldWithPath("color").type(STRING)
+                                        .description("색상"),
+                                fieldWithPath("content").type(STRING)
+                                        .optional()
+                                        .description("챌린지 내용")
+                        ),
+                        responseFields(successResponse())
+                                .and(
+                                        fieldWithPath("data").type(OBJECT)
+                                                .description("응답 데이터"),
+                                        fieldWithPath("data.id").type(NUMBER)
+                                                .description("챌린지 ID"),
+                                        fieldWithPath("data.category").type(OBJECT)
+                                                .description("카테고리 정보"),
+                                        fieldWithPath("data.category.id").type(NUMBER)
+                                                .description("카테고리 ID"),
+                                        fieldWithPath("data.category.name").type(STRING)
+                                                .description("카테고리 이름"),
+                                        fieldWithPath("data.record").type(OBJECT)
+                                                .description("기록 목록"),
+                                        fieldWithPath("data.record.successDates").type(ARRAY)
+                                                .description("성공 날짜"),
+                                        fieldWithPath("data.title").type(STRING)
+                                                .description("챌린지 제목"),
+                                        fieldWithPath("data.content").type(STRING)
+                                                .optional()
+                                                .description("챌린지 내용"),
+                                        fieldWithPath("data.durationInWeeks").type(NUMBER)
+                                                .description("챌린지 기간 (주 단위)"),
+                                        fieldWithPath("data.weekGoalCount").type(NUMBER)
+                                                .description("주간 목표 횟수"),
+                                        fieldWithPath("data.totalGoalCount").type(NUMBER)
+                                                .description("총 목표 횟수"),
+                                        fieldWithPath("data.color").type(STRING)
+                                                .description("챌린지 색상"),
+                                        fieldWithPath("data.startDateTime").type(STRING)
+                                                .description("챌린지 시작 일시"),
+                                        fieldWithPath("data.endDateTime").type(STRING)
+                                                .description("챌린지 종료 일시")
+                                )
+                ));
     }
 
 }

--- a/src/test/java/com/challenge/docs/ChallengeControllerDocsTest.java
+++ b/src/test/java/com/challenge/docs/ChallengeControllerDocsTest.java
@@ -3,12 +3,15 @@ package com.challenge.docs;
 import com.challenge.api.controller.challenge.ChallengeController;
 import com.challenge.api.service.category.response.CategoryResponse;
 import com.challenge.api.service.challenge.ChallengeService;
+import com.challenge.api.service.challenge.request.ChallengeAchieveServiceRequest;
+import com.challenge.api.service.challenge.request.ChallengeCancelServiceRequest;
 import com.challenge.api.service.challenge.request.ChallengeCreateServiceRequest;
 import com.challenge.api.service.challenge.response.ChallengeResponse;
 import com.challenge.api.service.record.response.RecordResponse;
 import com.challenge.domain.member.Member;
 import com.challenge.utils.date.DateUtils;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
@@ -16,13 +19,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.challenge.docs.RestDocsConfiguration.field;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.NULL;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
@@ -33,7 +33,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -47,171 +46,154 @@ class ChallengeControllerDocsTest extends RestDocsSupport {
         return new ChallengeController(challengeService);
     }
 
-    @DisplayName("신규 챌린지를 생성하는 API")
-    @Test
-    void createChallengeSuccess() throws Exception {
-        ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
-                .builder()
-                .title("챌린지 제목")
-                .durationInWeeks(1)
-                .weeklyGoalCount(2)
-                .categoryId(1L)
-                .color("색상")
-                .content("내용")
-                .build();
+    @Nested
+    @DisplayName("챌린지 생성 API")
+    class createChallenge {
 
-        given(challengeService.createChallenge(
-                any(Member.class),
-                any(ChallengeCreateServiceRequest.class),
-                any(LocalDateTime.class)
-        ))
-                .willReturn(ChallengeResponse
-                        .builder()
-                        .id(1L)
-                        .category(CategoryResponse.builder()
-                                .id(1L)
-                                .name("카테고리 이름")
-                                .build())
-                        .record(RecordResponse.builder()
-                                .successDates(
-                                        List.of(
-                                                DateUtils.toDayString(LocalDate.now()),
-                                                DateUtils.toDayString(LocalDate.now().plusDays(1))
-                                        )
-                                )
-                                .build())
-                        .title("챌린지 제목")
-                        .content("챌린지 내용")
-                        .durationInWeeks(2)
-                        .weekGoalCount(2)
-                        .totalGoalCount(4)
-                        .color("색상")
-                        .startDateTime(DateUtils.toDateTimeString(LocalDateTime.now()))
-                        .endDateTime(DateUtils.toDateTimeString(LocalDateTime.now().plusWeeks(2)))
-                        .build());
+        @DisplayName("챌린지 생성 성공 API")
+        @Test
+        void createChallengeSuccess() throws Exception {
+            ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest
+                    .builder()
+                    .title("챌린지 제목")
+                    .durationInWeeks(1)
+                    .weeklyGoalCount(2)
+                    .categoryId(1L)
+                    .color("색상")
+                    .content("내용")
+                    .build();
 
-        mockMvc.perform(
-                        post("/api/v1/challenges")
-                                .content(objectMapper.writeValueAsBytes(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andDo(document("challenge-create-success",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        requestFields(
-                                fieldWithPath("title").type(STRING)
-                                        .description("챌린지 제목"),
-                                fieldWithPath("durationInWeeks").type(NUMBER)
-                                        .description("챌린지 기간"),
-                                fieldWithPath("weeklyGoalCount").type(NUMBER)
-                                        .description("챌린지 주간 목표 횟수"),
-                                fieldWithPath("categoryId").type(NUMBER)
-                                        .description("카테고리 아이디"),
-                                fieldWithPath("color").type(STRING)
-                                        .description("색상"),
-                                fieldWithPath("content").type(STRING)
-                                        .description("챌린지 내용")
-                        ),
-                        responseFields(
-                                fieldWithPath("status").type(NUMBER)
-                                        .description("상태"),
-                                fieldWithPath("message").type(STRING)
-                                        .description("메시지"),
-                                fieldWithPath("code").type(NULL)
-                                        .description("코드 (성공 시 null)"),
-                                fieldWithPath("url").type(NULL)
-                                        .description("API 호출 URL (성공 시 null)"),
-                                fieldWithPath("data").type(OBJECT)
-                                        .description("응답 데이터"),
-                                fieldWithPath("data.id").type(NUMBER)
-                                        .description("챌린지 ID"),
-                                fieldWithPath("data.category").type(OBJECT)
-                                        .description("카테고리 정보"),
-                                fieldWithPath("data.category.id").type(NUMBER)
-                                        .description("카테고리 ID"),
-                                fieldWithPath("data.category.name").type(STRING)
-                                        .description("카테고리 이름"),
-                                fieldWithPath("data.record").type(OBJECT)
-                                        .description("기록 목록"),
-                                fieldWithPath("data.record.successDates").type(ARRAY)
-                                        .description("성공 날짜"),
-                                fieldWithPath("data.title").type(STRING)
-                                        .description("챌린지 제목"),
-                                fieldWithPath("data.content").type(STRING)
-                                        .description("챌린지 내용"),
-                                fieldWithPath("data.durationInWeeks").type(NUMBER)
-                                        .description("챌린지 기간 (주 단위)"),
-                                fieldWithPath("data.weekGoalCount").type(NUMBER)
-                                        .description("주간 목표 횟수"),
-                                fieldWithPath("data.totalGoalCount").type(NUMBER)
-                                        .description("총 목표 횟수"),
-                                fieldWithPath("data.color").type(STRING)
-                                        .description("챌린지 색상"),
-                                fieldWithPath("data.startDateTime").type(STRING)
-                                        .description("챌린지 시작 일시"),
-                                fieldWithPath("data.endDateTime").type(STRING)
-                                        .description("챌린지 종료 일시")
-                        )
-                ));
-    }
+            given(challengeService.createChallenge(
+                    any(Member.class),
+                    any(ChallengeCreateServiceRequest.class),
+                    any(LocalDateTime.class)
+            ))
+                    .willReturn(ChallengeResponse
+                            .builder()
+                            .id(1L)
+                            .category(CategoryResponse.builder()
+                                    .id(1L)
+                                    .name("카테고리 이름")
+                                    .build())
+                            .record(null)
+                            .title("챌린지 제목")
+                            .content("챌린지 내용")
+                            .durationInWeeks(2)
+                            .weekGoalCount(2)
+                            .totalGoalCount(4)
+                            .color("색상")
+                            .startDateTime(DateUtils.toDateTimeString(LocalDateTime.now()))
+                            .endDateTime(DateUtils.toDateTimeString(LocalDateTime.now().plusWeeks(2)))
+                            .build());
 
-    @DisplayName("챌린지 생성 실패 API (필수 필드 누락)")
-    @Test
-    void createChallengeFail() throws Exception {
-        ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest.builder()
-                .durationInWeeks(2)
-                .weeklyGoalCount(2)
-                .categoryId(1L)
-                .color("색상")
-                .content("내용")
-                .build();
+            mockMvc.perform(
+                            post("/api/v1/challenges")
+                                    .content(objectMapper.writeValueAsBytes(request))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andExpect(status().isOk())
+                    .andDo(restDocs.document(
+                            requestFields(
+                                    fieldWithPath("title").type(STRING)
+                                            .attributes(field("constraints", "공백포함 최대 30자"))
+                                            .description("챌린지 제목"),
+                                    fieldWithPath("durationInWeeks").type(NUMBER)
+                                            .description("챌린지 기간"),
+                                    fieldWithPath("weeklyGoalCount").type(NUMBER)
+                                            .description("챌린지 주간 목표 횟수"),
+                                    fieldWithPath("categoryId").type(NUMBER)
+                                            .description("카테고리 아이디"),
+                                    fieldWithPath("color").type(STRING)
+                                            .description("색상"),
+                                    fieldWithPath("content").type(STRING)
+                                            .optional()
+                                            .description("챌린지 내용")
+                            ),
+                            responseFields(successResponse())
+                                    .and(
+                                            fieldWithPath("data").type(OBJECT)
+                                                    .description("응답 데이터"),
+                                            fieldWithPath("data.id").type(NUMBER)
+                                                    .description("챌린지 ID"),
+                                            fieldWithPath("data.category").type(OBJECT)
+                                                    .description("카테고리 정보"),
+                                            fieldWithPath("data.category.id").type(NUMBER)
+                                                    .description("카테고리 ID"),
+                                            fieldWithPath("data.category.name").type(STRING)
+                                                    .description("카테고리 이름"),
+                                            fieldWithPath("data.record").type(NULL)
+                                                    .optional()
+                                                    .description("기록 목록"),
+                                            fieldWithPath("data.title").type(STRING)
+                                                    .description("챌린지 제목"),
+                                            fieldWithPath("data.content").type(STRING)
+                                                    .optional()
+                                                    .description("챌린지 내용"),
+                                            fieldWithPath("data.durationInWeeks").type(NUMBER)
+                                                    .description("챌린지 기간 (주 단위)"),
+                                            fieldWithPath("data.weekGoalCount").type(NUMBER)
+                                                    .description("주간 목표 횟수"),
+                                            fieldWithPath("data.totalGoalCount").type(NUMBER)
+                                                    .description("총 목표 횟수"),
+                                            fieldWithPath("data.color").type(STRING)
+                                                    .description("챌린지 색상"),
+                                            fieldWithPath("data.startDateTime").type(STRING)
+                                                    .description("챌린지 시작 일시"),
+                                            fieldWithPath("data.endDateTime").type(STRING)
+                                                    .description("챌린지 종료 일시")
+                                    )
+                    ));
+        }
 
-        mockMvc.perform(post("/api/v1/challenges")
-                        .content(objectMapper.writeValueAsBytes(request))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andDo(document("challenge-create-fail",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        requestFields(
-                                fieldWithPath("title").type(NULL)
-                                        .description("챌린지 제목"),
-                                fieldWithPath("durationInWeeks").type(NUMBER)
-                                        .description("챌린지 기간"),
-                                fieldWithPath("weeklyGoalCount").type(NUMBER)
-                                        .description("챌린지 주간 목표 횟수"),
-                                fieldWithPath("categoryId").type(NUMBER)
-                                        .description("카테고리 아이디"),
-                                fieldWithPath("color").type(STRING)
-                                        .description("색상"),
-                                fieldWithPath("content").type(STRING)
-                                        .description("챌린지 내용")
-                        ),
-                        responseFields(
-                                fieldWithPath("status").type(NUMBER)
-                                        .description("상태 코드"),
-                                fieldWithPath("message").type(STRING)
-                                        .description("검증 실패 메시지"),
-                                fieldWithPath("code").type(STRING)
-                                        .description("에러 코드"),
-                                fieldWithPath("url").type(STRING)
-                                        .description("API 호출 URL"),
-                                fieldWithPath("data").type(NULL)
-                                        .description("응답 데이터 (실패 시 null)")
-                        )
-                ));
+        @DisplayName("챌린지 생성 실패 API (필수 필드 누락)")
+        @Test
+        void createChallengeFail() throws Exception {
+            ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest.builder()
+                    .durationInWeeks(2)
+                    .weeklyGoalCount(2)
+                    .categoryId(1L)
+                    .color("색상")
+                    .content("내용")
+                    .build();
+
+            mockMvc.perform(post("/api/v1/challenges")
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andDo(restDocs.document(
+                            requestFields(
+                                    fieldWithPath("title").type(NULL)
+                                            .description("챌린지 제목"),
+                                    fieldWithPath("durationInWeeks").type(NUMBER)
+                                            .description("챌린지 기간"),
+                                    fieldWithPath("weeklyGoalCount").type(NUMBER)
+                                            .description("챌린지 주간 목표 횟수"),
+                                    fieldWithPath("categoryId").type(NUMBER)
+                                            .description("카테고리 아이디"),
+                                    fieldWithPath("color").type(STRING)
+                                            .description("색상"),
+                                    fieldWithPath("content").type(STRING)
+                                            .optional()
+                                            .description("챌린지 내용")
+                            ),
+                            responseFields(failResponse())
+                    ));
+        }
+
     }
 
     @DisplayName("챌린지를 달성 완료 하는 API")
     @Test
-    void successChallenge() throws Exception {
+    void achieveChallenge() throws Exception {
+        Long challengeId = 1L;
+        ChallengeAchieveServiceRequest achieveServiceRequest = ChallengeAchieveServiceRequest.builder()
+                .achieveDate(DateUtils.toDayString(LocalDate.now()))
+                .build();
+
         given(challengeService.achieveChallenge(
                 any(Member.class),
                 any(Long.class),
-                any(String.class)
+                any(ChallengeAchieveServiceRequest.class)
         ))
                 .willReturn(ChallengeResponse
                         .builder()
@@ -239,62 +221,160 @@ class ChallengeControllerDocsTest extends RestDocsSupport {
                         .build());
 
         mockMvc.perform(
-                        post("/api/v1/challenges/{challengeId}/achieve?achieveDate", 1L)
+                        post("/api/v1/challenges/{challengeId}/achieve", challengeId)
+                                .content(objectMapper.writeValueAsBytes(achieveServiceRequest))
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .param("achieveDate", DateUtils.toDayString(LocalDate.now()))
                 )
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andDo(document("challenge-achieve",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
+                .andDo(restDocs.document(
                         pathParameters(
-                                parameterWithName("challengeId").description("챌린지 아이디")
+                                parameterWithName("challengeId")
+                                        .attributes(field("type", "Long"))
+                                        .description("챌린지 아이디")
                         ),
-                        queryParameters(
-                                parameterWithName("achieveDate").description("달성 날짜 (yyyy-MM-dd)")
+                        requestFields(
+                                fieldWithPath("achieveDate").type(STRING)
+                                        .attributes(field("constraints", "yyyy-MM-dd"))
+                                        .description("달성 일자")
                         ),
-                        responseFields(
-                                fieldWithPath("status").type(NUMBER)
-                                        .description("상태"),
-                                fieldWithPath("message").type(STRING)
-                                        .description("메시지"),
-                                fieldWithPath("code").type(NULL)
-                                        .description("코드 (성공 시 null)"),
-                                fieldWithPath("url").type(NULL)
-                                        .description("API 호출 URL (성공 시 null)"),
-                                fieldWithPath("data").type(OBJECT)
-                                        .description("응답 데이터"),
-                                fieldWithPath("data.id").type(NUMBER)
-                                        .description("챌린지 ID"),
-                                fieldWithPath("data.category").type(OBJECT)
-                                        .description("카테고리 정보"),
-                                fieldWithPath("data.category.id").type(NUMBER)
-                                        .description("카테고리 ID"),
-                                fieldWithPath("data.category.name").type(STRING)
-                                        .description("카테고리 이름"),
-                                fieldWithPath("data.record").type(OBJECT)
-                                        .description("기록 목록"),
-                                fieldWithPath("data.record.successDates").type(ARRAY)
-                                        .description("성공 날짜"),
-                                fieldWithPath("data.title").type(STRING)
-                                        .description("챌린지 제목"),
-                                fieldWithPath("data.content").type(STRING)
-                                        .description("챌린지 내용"),
-                                fieldWithPath("data.durationInWeeks").type(NUMBER)
-                                        .description("챌린지 기간 (주 단위)"),
-                                fieldWithPath("data.weekGoalCount").type(NUMBER)
-                                        .description("주간 목표 횟수"),
-                                fieldWithPath("data.totalGoalCount").type(NUMBER)
-                                        .description("총 목표 횟수"),
-                                fieldWithPath("data.color").type(STRING)
-                                        .description("챌린지 색상"),
-                                fieldWithPath("data.startDateTime").type(STRING)
-                                        .description("챌린지 시작 일시"),
-                                fieldWithPath("data.endDateTime").type(STRING)
-                                        .description("챌린지 종료 일시")
-                        )
+                        responseFields(successResponse())
+                                .and(
+                                        fieldWithPath("data").type(OBJECT)
+                                                .description("응답 데이터"),
+                                        fieldWithPath("data.id").type(NUMBER)
+                                                .description("챌린지 ID"),
+                                        fieldWithPath("data.category").type(OBJECT)
+                                                .description("카테고리 정보"),
+                                        fieldWithPath("data.category.id").type(NUMBER)
+                                                .description("카테고리 ID"),
+                                        fieldWithPath("data.category.name").type(STRING)
+                                                .description("카테고리 이름"),
+                                        fieldWithPath("data.record").type(OBJECT)
+                                                .description("기록 목록"),
+                                        fieldWithPath("data.record.successDates").type(ARRAY)
+                                                .description("성공 날짜"),
+                                        fieldWithPath("data.title").type(STRING)
+                                                .description("챌린지 제목"),
+                                        fieldWithPath("data.content").type(STRING)
+                                                .optional()
+                                                .description("챌린지 내용"),
+                                        fieldWithPath("data.durationInWeeks").type(NUMBER)
+                                                .description("챌린지 기간 (주 단위)"),
+                                        fieldWithPath("data.weekGoalCount").type(NUMBER)
+                                                .description("주간 목표 횟수"),
+                                        fieldWithPath("data.totalGoalCount").type(NUMBER)
+                                                .description("총 목표 횟수"),
+                                        fieldWithPath("data.color").type(STRING)
+                                                .description("챌린지 색상"),
+                                        fieldWithPath("data.startDateTime").type(STRING)
+                                                .description("챌린지 시작 일시"),
+                                        fieldWithPath("data.endDateTime").type(STRING)
+                                                .description("챌린지 종료 일시")
+                                )
                 ));
+    }
+
+    @DisplayName("챌린지를 취소하는 API")
+    @Test
+    void cancelChallenge() throws Exception {
+        // given
+        Long challengeId = 1L;
+        String cancelDate = DateUtils.toDayString(LocalDate.now());
+        ChallengeCancelServiceRequest challengeCancelServiceRequest = ChallengeCancelServiceRequest.builder()
+                .cancelDate(cancelDate)
+                .build();
+
+        given(challengeService.cancelChallenge(
+                any(Member.class),
+                any(Long.class),
+                any(ChallengeCancelServiceRequest.class)
+        ))
+                .willReturn(ChallengeResponse
+                        .builder()
+                        .id(1L)
+                        .category(CategoryResponse.builder()
+                                .id(1L)
+                                .name("카테고리 이름")
+                                .build())
+                        .record(RecordResponse.builder()
+                                .successDates(
+                                        List.of(
+                                                DateUtils.toDayString(LocalDate.now()),
+                                                DateUtils.toDayString(LocalDate.now().plusDays(1))
+                                        )
+                                )
+                                .build())
+                        .title("챌린지 제목")
+                        .content("챌린지 내용")
+                        .durationInWeeks(2)
+                        .weekGoalCount(2)
+                        .totalGoalCount(4)
+                        .color("색상")
+                        .startDateTime(DateUtils.toDateTimeString(LocalDateTime.now()))
+                        .endDateTime(DateUtils.toDateTimeString(LocalDateTime.now().plusWeeks(2)))
+                        .build());
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/v1/challenges/{challengeId}/cancel", challengeId)
+                                .content(objectMapper.writeValueAsString(challengeCancelServiceRequest))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        pathParameters(
+                                parameterWithName("challengeId")
+                                        .attributes(field("type", "Long"))
+                                        .description("챌린지 아이디")
+                        ),
+                        responseFields(successResponse())
+                                .and(
+                                        fieldWithPath("data").type(OBJECT)
+                                                .description("응답 데이터"),
+                                        fieldWithPath("data.id").type(NUMBER)
+                                                .description("챌린지 ID"),
+                                        fieldWithPath("data.category").type(OBJECT)
+                                                .description("카테고리 정보"),
+                                        fieldWithPath("data.category.id").type(NUMBER)
+                                                .description("카테고리 ID"),
+                                        fieldWithPath("data.category.name").type(STRING)
+                                                .description("카테고리 이름"),
+                                        fieldWithPath("data.record").type(OBJECT)
+                                                .optional()
+                                                .description("기록 목록"),
+                                        fieldWithPath("data.record.successDates").type(ARRAY)
+                                                .optional()
+                                                .description("성공 날짜"),
+                                        fieldWithPath("data.title").type(STRING)
+                                                .description("챌린지 제목"),
+                                        fieldWithPath("data.content").type(STRING)
+                                                .optional()
+                                                .description("챌린지 내용"),
+                                        fieldWithPath("data.durationInWeeks").type(NUMBER)
+                                                .description("챌린지 기간 (주 단위)"),
+                                        fieldWithPath("data.weekGoalCount").type(NUMBER)
+                                                .description("주간 목표 횟수"),
+                                        fieldWithPath("data.totalGoalCount").type(NUMBER)
+                                                .description("총 목표 횟수"),
+                                        fieldWithPath("data.color").type(STRING)
+                                                .description("챌린지 색상"),
+                                        fieldWithPath("data.startDateTime").type(STRING)
+                                                .description("챌린지 시작 일시"),
+                                        fieldWithPath("data.endDateTime").type(STRING)
+                                                .description("챌린지 종료 일시")
+                                )
+                ));
+    }
+
+    @DisplayName("챌린지를 수정하는 API")
+    @Test
+    void updateChallenge() throws Exception {
+        // given
+
+        // when
+
+        // then
     }
 
 }

--- a/src/test/java/com/challenge/docs/MemberControllerDocsTest.java
+++ b/src/test/java/com/challenge/docs/MemberControllerDocsTest.java
@@ -142,7 +142,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("nickname").type(STRING)
                                             .description("닉네임")
-                                            .attributes(field("4~10자, 특수문자 및 공백 불가"))
+                                            .attributes(field("constraints", "4~10자, 특수문자 및 공백 불가"))
                             ),
                             responseFields(successResponse())
                                     .and(
@@ -172,7 +172,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("nickname").type(STRING)
                                             .description("닉네임")
-                                            .attributes(field("4~10자, 특수문자 및 공백 불가"))
+                                            .attributes(field("constraints", "4~10자, 특수문자 및 공백 불가"))
                             ),
                             responseFields(failResponse())
                     ));
@@ -215,7 +215,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("nickname").type(STRING)
                                             .description("닉네임")
-                                            .attributes(field("4~10자, 특수문자 및 공백 불가"))
+                                            .attributes(field("constraints", "4~10자, 특수문자 및 공백 불가"))
                             ),
                             responseFields(successResponse())
                                     .and(
@@ -245,7 +245,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("nickname").type(STRING)
                                             .description("닉네임")
-                                            .attributes(field("4~10자, 특수문자 및 공백 불가"))
+                                            .attributes(field("constraints", "4~10자, 특수문자 및 공백 불가"))
                             ),
                             responseFields(failResponse())
                     ));
@@ -288,7 +288,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("birth").type(STRING)
                                             .description("생년월일")
-                                            .attributes(field("yyyy-MM-dd"))
+                                            .attributes(field("constraints", "yyyy-MM-dd"))
                             ),
                             responseFields(successResponse())
                                     .and(
@@ -318,7 +318,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("birth").type(STRING)
                                             .description("생년월일")
-                                            .attributes(field("yyyy-MM-dd"))
+                                            .attributes(field("constraints", "yyyy-MM-dd"))
                             ),
                             responseFields(failResponse())
                     ));
@@ -361,7 +361,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("gender").type(STRING)
                                             .description("성별")
-                                            .attributes(field("MALE, FEMALE"))
+                                            .attributes(field("constraints", "MALE, FEMALE"))
                             ),
                             responseFields(successResponse())
                                     .and(
@@ -391,7 +391,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("gender").type(NULL)
                                             .description("성별")
-                                            .attributes(field("MALE, FEMALE"))
+                                            .attributes(field("constraints", "MALE, FEMALE"))
                             ),
                             responseFields(failResponse())
                     ));
@@ -434,7 +434,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("jobId").type(NUMBER)
                                             .description("직무 id")
-                                            .attributes(field("1~20 사이의 숫자"))
+                                            .attributes(field("constraints", "1~20 사이의 숫자"))
                             ),
                             responseFields(successResponse())
                                     .and(
@@ -464,7 +464,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("jobId").type(NULL)
                                             .description("직무 id")
-                                            .attributes(field("1~20 사이의 숫자"))
+                                            .attributes(field("constraints", "1~20 사이의 숫자"))
                             ),
                             responseFields(failResponse())
                     ));
@@ -490,7 +490,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("jobId").type(NUMBER)
                                             .description("직무 id")
-                                            .attributes(field("1~20 사이의 숫자"))
+                                            .attributes(field("constraints", "1~20 사이의 숫자"))
                             ),
                             responseFields(failResponse())
                     ));
@@ -516,7 +516,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("jobId").type(NUMBER)
                                             .description("직무 id")
-                                            .attributes(field("1~20 사이의 숫자"))
+                                            .attributes(field("constraints", "1~20 사이의 숫자"))
                             ),
                             responseFields(failResponse())
                     ));
@@ -559,7 +559,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("yearId").type(NUMBER)
                                             .description("연차 id")
-                                            .attributes(field("1~4 사이의 숫자"))
+                                            .attributes(field("constraints", "1~4 사이의 숫자"))
                             ),
                             responseFields(successResponse())
                                     .and(
@@ -589,7 +589,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("yearId").type(NUMBER)
                                             .description("연차 id")
-                                            .attributes(field("1~4 사이의 숫자"))
+                                            .attributes(field("constraints", "1~4 사이의 숫자"))
                             ),
                             responseFields(failResponse())
                     ));
@@ -615,7 +615,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             requestFields(
                                     fieldWithPath("yearId").type(NUMBER)
                                             .description("연차 id")
-                                            .attributes(field("1~4 사이의 숫자"))
+                                            .attributes(field("constraints", "1~4 사이의 숫자"))
                             ),
                             responseFields(failResponse())
                     ));

--- a/src/test/java/com/challenge/docs/RestDocsConfiguration.java
+++ b/src/test/java/com/challenge/docs/RestDocsConfiguration.java
@@ -22,8 +22,9 @@ public class RestDocsConfiguration {
                         modifyHeaders()
                                 .remove("Content-Length")
                                 .remove("Host"),
-                        prettyPrint()),  // pretty json 적용
-                preprocessResponse(prettyPrint())    // pretty json 적용
+                        prettyPrint()
+                ),
+                preprocessResponse(prettyPrint())
         );
     }
 

--- a/src/test/java/com/challenge/docs/RestDocsConfiguration.java
+++ b/src/test/java/com/challenge/docs/RestDocsConfiguration.java
@@ -28,8 +28,8 @@ public class RestDocsConfiguration {
         );
     }
 
-    public static Attributes.Attribute field(final String value) {
-        return new Attributes.Attribute("constraints", value);
+    public static Attributes.Attribute field(final String key, final String value) {
+        return new Attributes.Attribute(key, value);
     }
 
 }

--- a/src/test/java/com/challenge/docs/RestDocsSupport.java
+++ b/src/test/java/com/challenge/docs/RestDocsSupport.java
@@ -19,7 +19,6 @@ import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
-
 /**
  * Spring REST Docs
  *
@@ -50,8 +49,6 @@ public abstract class RestDocsSupport {
 
     /**
      * 성공 공통 응답 필드 반환
-     *
-     * @return
      */
     protected FieldDescriptor[] successResponse() {
         return new FieldDescriptor[]{
@@ -64,8 +61,6 @@ public abstract class RestDocsSupport {
 
     /**
      * 실패 공통 응답 필드 반환
-     *
-     * @return
      */
     protected FieldDescriptor[] failResponse() {
         return new FieldDescriptor[]{

--- a/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
@@ -1,0 +1,17 @@
+==== Path Parameters
+
+.{{path}}
+
+|===
+|Parameter|Type|Constraints|Description
+
+{{#parameters}}
+
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#type}}{{.}}{{/type}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraints}}{{.}}{{/constraints}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/parameters}}
+
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,4 +1,5 @@
 ==== Request Fields
+
 |===
 |Path|Type|Optional|Constraints|Description
 

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,4 +1,5 @@
 ==== Response Fields
+
 |===
 |Path|Type|Optional|Description
 


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
챌린지 수정 테스트 및 문서화
## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- Attribute 기존에 key 'constraints'로 고정되어 있는거 입력 받을수 잇도록 변경
- ddl-auto update -> none 변경
- 챌린지 달성 및 취소 request param -> json 받도록 수정
- 챌린지 수정 테스트 및 문서화 구현 

## ⏳ 작업 내용
- [x] Attribute 기존에 key 'constraints'로 고정되어 있는거 입력 받을수 잇도록 변경
- [x] ddl-auto update -> none 변경
- [x] 챌린지 달성 및 취소 request param -> json 받도록 수정
- [x] 챌린지 수정 테스트 및 문서화 구현 

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
