### PR TITLE
[Feat/73] 프로필 사진 조회 API 구현

### DIFF
--- a/src/main/java/com/challenge/api/controller/member/MemberController.java
+++ b/src/main/java/com/challenge/api/controller/member/MemberController.java
@@ -34,6 +34,11 @@ public class MemberController {
         return ApiResponse.ok(memberService.getMemberInfo(member));
     }
 
+    @GetMapping("/profile/img")
+    public ApiResponse<String> getMemberProfileImg(@AuthMember Member member) {
+        return ApiResponse.ok(memberService.getMemberProfileImg(member));
+    }
+
     @PostMapping("/nickname/valid")
     public ApiResponse<String> checkNicknameIsValid(@RequestBody @Valid CheckNicknameRequest request) {
         return ApiResponse.ok(memberService.checkNicknameIsValid(request.toServiceRequest()));

--- a/src/main/java/com/challenge/api/service/member/MemberService.java
+++ b/src/main/java/com/challenge/api/service/member/MemberService.java
@@ -40,6 +40,16 @@ public class MemberService {
     }
 
     /**
+     * 회원 프로필 사진 조회 메소드
+     *
+     * @param member
+     * @return
+     */
+    public String getMemberProfileImg(Member member) {
+        return member.getProfileImg();
+    }
+
+    /**
      * 해당 닉네임이 사용 가능 여부를 조회하는 메소드
      *
      * @param request

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,6 +71,10 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+
 social:
   kakao:
     apikey: ${KAKAO_API_KEY}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
프로필 사진 조회 API 구현

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 프로필 사진 조회 API 구현
- MultipartFIle 파일 업로드 용량 제한 5MB로 설정

## ⏳ 작업 내용
- [x] 프로필 사진 조회 API 구현
- [x] MultipartFIle 파일 업로드 용량 제한 5MB로 설정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
