### PR TITLE
fix: 챌린지 생성시 카테고리아이디가 null로 들어오는 버그 수정

### DIFF
--- a/src/main/java/com/challenge/api/controller/challenge/request/ChallengeCreateRequest.java
+++ b/src/main/java/com/challenge/api/controller/challenge/request/ChallengeCreateRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -34,11 +35,23 @@ public class ChallengeCreateRequest {
     @Size(max = 500, message = "상세 내용은 공백 포함 최대 500자 이하여야 합니다.")
     private String content;
 
+    @Builder
+    private ChallengeCreateRequest(String title, int durationInWeeks, int weeklyGoalCount, Long categoryId,
+            String color, String content) {
+        this.title = title;
+        this.durationInWeeks = durationInWeeks;
+        this.weeklyGoalCount = weeklyGoalCount;
+        this.categoryId = categoryId;
+        this.color = color;
+        this.content = content;
+    }
+
     public ChallengeCreateServiceRequest toServiceRequest() {
         return ChallengeCreateServiceRequest.builder()
                 .title(title)
                 .durationInWeeks(durationInWeeks)
                 .weeklyGoalCount(weeklyGoalCount)
+                .categoryId(categoryId)
                 .color(color)
                 .content(content)
                 .build();

--- a/src/test/java/com/challenge/api/service/challenge/ChallengeServiceTest.java
+++ b/src/test/java/com/challenge/api/service/challenge/ChallengeServiceTest.java
@@ -1,5 +1,6 @@
 package com.challenge.api.service.challenge;
 
+import com.challenge.api.controller.challenge.request.ChallengeCreateRequest;
 import com.challenge.api.service.challenge.request.ChallengeAchieveServiceRequest;
 import com.challenge.api.service.challenge.request.ChallengeCancelServiceRequest;
 import com.challenge.api.service.challenge.request.ChallengeCreateServiceRequest;
@@ -112,7 +113,7 @@ class ChallengeServiceTest {
         Category category = createCategory("카테고리");
         categoryRepository.save(category);
 
-        ChallengeCreateServiceRequest request = ChallengeCreateServiceRequest.builder()
+        ChallengeCreateRequest request = ChallengeCreateRequest.builder()
                 .title("제목")
                 .durationInWeeks(2)
                 .weeklyGoalCount(3)
@@ -122,7 +123,10 @@ class ChallengeServiceTest {
                 .build();
 
         // when
-        ChallengeResponse challengeResponse = challengeService.createChallenge(member, request, startDateTime);
+        ChallengeResponse challengeResponse = challengeService.createChallenge(
+                member,
+                request.toServiceRequest(),
+                startDateTime);
 
         // then
         assertThat(challengeResponse.getId()).isNotNull();


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
챌린지 생성시 카테고리아이디가 null로 들어오는 버그 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 챌린지 생성시 카테고리아이디가 null로 들어오는 버그 수정
- 테스트 코드 수정

## ⏳ 작업 내용
- [x] 테스트 코드 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
