### PR TITLE
[Feat/66] FCM 알림 전송 구현 및 테스트 API 구현

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -23,6 +23,7 @@ jobs:
       S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
       S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
       S3_REGION: ${{ secrets.S3_REGION }}
+      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
 
     steps:
       # 1. GitHub Repository 파일 불러오기
@@ -52,7 +53,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # 6. Docker 이미지 생성 및 Push
+      # 6. firebase 설정 파일 생성
+      - name: Create firebase.json from Secret
+        run: |
+          mkdir -p src/main/resources/firebase
+          echo "${{ secrets.FIREBASE_JSON }}" > src/main/resources/firebase/firebase.json
+
+      # 7. Docker 이미지 생성 및 Push
       - name: Docker 이미지 생성 및 push
         uses: docker/build-push-action@v6
         with:
@@ -74,9 +81,10 @@ jobs:
             S3_SECRET_KEY= ${{ secrets.S3_SECRET_KEY }}
             S3_BUCKET_NAME= ${{ secrets.S3_BUCKET_NAME }}
             S3_REGION= ${{ secrets.S3_REGION }}
+            FIREBASE_PROJECT_ID= ${{ secrets.FIREBASE_PROJECT_ID }}
 
       ## CD (Continuous Deployment) 파트
-      # 7. EC2에 SSH로 접속하여 Docker 컨테이너 실행
+      # 8. EC2에 SSH로 접속하여 Docker 컨테이너 실행
       - name: EC2에 배포
         uses: appleboy/ssh-action@v1.1.0
         with:
@@ -105,4 +113,5 @@ jobs:
             -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} \
             -e S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }} \
             -e S3_REGION=${{ secrets.S3_REGION }} \
+            -e FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }} \
             ${{ secrets.DOCKERHUB_USERNAME }}/challenge:${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 /src/main/generated
 /src/main/resources/application-test.yml
 /src/main/resources/application-local.yml
+/src/main/resources/firebase/**
 
 
 # General

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ARG S3_ACCESS_KEY
 ARG S3_SECRET_KEY
 ARG S3_BUCKET_NAME
 ARG S3_REGION
+ARG FIREBASE_PROJECT_ID
 
 # 라이브러리 설치에 필요한 파일만 복사
 COPY build.gradle settings.gradle ./

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,10 @@ dependencies {
 
     // s3
     implementation "software.amazon.awssdk:s3:2.13.0"
+
+    // Google Firebase
+    implementation 'com.google.firebase:firebase-admin:9.1.1'
+    
 }
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/challenge/api/controller/fcm/FcmController.java
+++ b/src/main/java/com/challenge/api/controller/fcm/FcmController.java
@@ -2,7 +2,8 @@ package com.challenge.api.controller.fcm;
 
 import com.challenge.annotation.AuthMember;
 import com.challenge.api.ApiResponse;
-import com.challenge.api.controller.fcm.request.FcmSendRequest;
+import com.challenge.api.controller.fcm.request.FcmSendByIdRequest;
+import com.challenge.api.controller.fcm.request.FcmSendByTokenRequest;
 import com.challenge.api.controller.fcm.request.TokenSaveRequest;
 import com.challenge.api.service.fcm.FcmService;
 import com.challenge.domain.member.Member;
@@ -21,9 +22,14 @@ public class FcmController {
 
     private final FcmService fcmService;
 
-    @PostMapping("/send")
-    public ApiResponse<String> pushMessage(@RequestBody FcmSendRequest request) {
-        return ApiResponse.ok(fcmService.sendMessage(FcmSendRequest.toFcmMessage(request)));
+    @PostMapping("/send/token")
+    public ApiResponse<String> sendMessageByToken(@Valid @RequestBody FcmSendByTokenRequest request) {
+        return ApiResponse.ok(fcmService.sendMessage(FcmSendByTokenRequest.toFcmMessage(request)));
+    }
+
+    @PostMapping("/send/member")
+    public ApiResponse<String> sendMessageByMemberId(@Valid @RequestBody FcmSendByIdRequest request) {
+        return ApiResponse.ok(fcmService.sendMessageById(request));
     }
 
     @PostMapping

--- a/src/main/java/com/challenge/api/controller/fcm/FcmController.java
+++ b/src/main/java/com/challenge/api/controller/fcm/FcmController.java
@@ -8,6 +8,7 @@ import com.challenge.api.service.fcm.FcmService;
 import com.challenge.domain.member.Member;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,6 +30,11 @@ public class FcmController {
     public ApiResponse<String> saveToken(@Valid @RequestBody TokenSaveRequest request,
                                          @AuthMember Member member) {
         return ApiResponse.ok(fcmService.saveToken(request.toServiceRequest(), member));
+    }
+
+    @DeleteMapping
+    public ApiResponse<String> deleteToken(@AuthMember Member member) {
+        return ApiResponse.ok(fcmService.deleteToken(member));
     }
 
 }

--- a/src/main/java/com/challenge/api/controller/fcm/FcmController.java
+++ b/src/main/java/com/challenge/api/controller/fcm/FcmController.java
@@ -1,8 +1,12 @@
 package com.challenge.api.controller.fcm;
 
+import com.challenge.annotation.AuthMember;
 import com.challenge.api.ApiResponse;
 import com.challenge.api.controller.fcm.request.FcmSendRequest;
+import com.challenge.api.controller.fcm.request.TokenSaveRequest;
 import com.challenge.api.service.fcm.FcmService;
+import com.challenge.domain.member.Member;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +23,12 @@ public class FcmController {
     @PostMapping("/send")
     public ApiResponse<String> pushMessage(@RequestBody FcmSendRequest request) {
         return ApiResponse.ok(fcmService.sendMessage(FcmSendRequest.toFcmMessage(request)));
+    }
+
+    @PostMapping
+    public ApiResponse<String> saveToken(@Valid @RequestBody TokenSaveRequest request,
+                                         @AuthMember Member member) {
+        return ApiResponse.ok(fcmService.saveToken(request.toServiceRequest(), member));
     }
 
 }

--- a/src/main/java/com/challenge/api/controller/fcm/FcmController.java
+++ b/src/main/java/com/challenge/api/controller/fcm/FcmController.java
@@ -1,0 +1,24 @@
+package com.challenge.api.controller.fcm;
+
+import com.challenge.api.ApiResponse;
+import com.challenge.api.controller.fcm.request.FcmSendRequest;
+import com.challenge.api.service.fcm.FcmService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/fcm")
+public class FcmController {
+
+    private final FcmService fcmService;
+
+    @PostMapping("/send")
+    public ApiResponse<String> pushMessage(@RequestBody FcmSendRequest request) {
+        return ApiResponse.ok(fcmService.sendMessage(FcmSendRequest.toFcmMessage(request)));
+    }
+
+}

--- a/src/main/java/com/challenge/api/controller/fcm/request/FcmSendByIdRequest.java
+++ b/src/main/java/com/challenge/api/controller/fcm/request/FcmSendByIdRequest.java
@@ -1,0 +1,29 @@
+package com.challenge.api.controller.fcm.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FcmSendByIdRequest {
+
+    @NotNull
+    private Long memberId;
+
+    @NotEmpty
+    private String title;
+
+    @NotEmpty
+    private String body;
+
+    @Builder
+    private FcmSendByIdRequest(Long memberId, String title, String body) {
+        this.memberId = memberId;
+        this.title = title;
+        this.body = body;
+    }
+
+}

--- a/src/main/java/com/challenge/api/controller/fcm/request/FcmSendByTokenRequest.java
+++ b/src/main/java/com/challenge/api/controller/fcm/request/FcmSendByTokenRequest.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class FcmSendRequest {
+public class FcmSendByTokenRequest {
 
     @NotEmpty
     private String token;
@@ -20,13 +20,13 @@ public class FcmSendRequest {
     private String body;
 
     @Builder
-    private FcmSendRequest(String token, String title, String body) {
+    private FcmSendByTokenRequest(String token, String title, String body) {
         this.token = token;
         this.title = title;
         this.body = body;
     }
 
-    public static FcmMessage toFcmMessage(FcmSendRequest request) {
+    public static FcmMessage toFcmMessage(FcmSendByTokenRequest request) {
         return FcmMessage.of(request.getToken(), request.getTitle(), request.getBody());
     }
 

--- a/src/main/java/com/challenge/api/controller/fcm/request/FcmSendRequest.java
+++ b/src/main/java/com/challenge/api/controller/fcm/request/FcmSendRequest.java
@@ -1,0 +1,33 @@
+package com.challenge.api.controller.fcm.request;
+
+import com.challenge.api.service.fcm.request.FcmMessage;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FcmSendRequest {
+
+    @NotEmpty
+    private String token;
+
+    @NotEmpty
+    private String title;
+
+    @NotEmpty
+    private String body;
+
+    @Builder
+    private FcmSendRequest(String token, String title, String body) {
+        this.token = token;
+        this.title = title;
+        this.body = body;
+    }
+
+    public static FcmMessage toFcmMessage(FcmSendRequest request) {
+        return FcmMessage.of(request.getToken(), request.getTitle(), request.getBody());
+    }
+
+}

--- a/src/main/java/com/challenge/api/controller/fcm/request/TokenSaveRequest.java
+++ b/src/main/java/com/challenge/api/controller/fcm/request/TokenSaveRequest.java
@@ -1,0 +1,27 @@
+package com.challenge.api.controller.fcm.request;
+
+import com.challenge.api.service.fcm.request.TokenSaveServiceRequest;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenSaveRequest {
+
+    @NotBlank(message = "token은 필수 입력값입니다.")
+    String token;
+
+    @Builder
+    private TokenSaveRequest(String token) {
+        this.token = token;
+    }
+
+    public TokenSaveServiceRequest toServiceRequest() {
+        return TokenSaveServiceRequest.builder()
+                .token(this.token)
+                .build();
+    }
+
+}

--- a/src/main/java/com/challenge/api/service/fcm/FcmService.java
+++ b/src/main/java/com/challenge/api/service/fcm/FcmService.java
@@ -1,8 +1,10 @@
 package com.challenge.api.service.fcm;
 
+import com.challenge.api.controller.fcm.request.FcmSendByIdRequest;
 import com.challenge.api.service.fcm.request.FcmMessage;
 import com.challenge.api.service.fcm.request.TokenSaveServiceRequest;
 import com.challenge.domain.member.Member;
+import com.challenge.domain.member.MemberRepository;
 import com.challenge.exception.ErrorCode;
 import com.challenge.exception.GlobalException;
 import com.google.firebase.messaging.ApnsConfig;
@@ -21,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class FcmService {
 
     private final FirebaseMessaging firebaseMessaging;
+    private final MemberRepository memberRepository;
 
     public String sendMessage(FcmMessage request) {
         try {
@@ -34,6 +37,19 @@ public class FcmService {
         }
 
         return "fcm 푸시 발송 성공";
+    }
+
+    public String sendMessageById(FcmSendByIdRequest request) {
+        Member member = memberRepository.findById(request.getMemberId()).orElseThrow(
+                () -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.getFcmToken() == null) {
+            throw new GlobalException(ErrorCode.FCM_TOKEN_NOT_FOUND);
+        }
+
+        FcmMessage fcmMessage = FcmMessage.of(member.getFcmToken(), request.getTitle(), request.getBody());
+
+        return sendMessage(fcmMessage);
     }
 
     @Transactional

--- a/src/main/java/com/challenge/api/service/fcm/FcmService.java
+++ b/src/main/java/com/challenge/api/service/fcm/FcmService.java
@@ -43,6 +43,13 @@ public class FcmService {
         return "fcm 토큰 저장 성공";
     }
 
+    @Transactional
+    public String deleteToken(Member member) {
+        member.updateFcmToken(null);
+
+        return "fcm 토큰 삭제 성공";
+    }
+
     private ApnsConfig getApnsConfig(FcmMessage request) {
         ApsAlert alert = ApsAlert.builder().setTitle(request.getTitle()).setBody(request.getBody()).build();
         Aps aps = Aps.builder().setAlert(alert).setSound("default").build();

--- a/src/main/java/com/challenge/api/service/fcm/FcmService.java
+++ b/src/main/java/com/challenge/api/service/fcm/FcmService.java
@@ -1,6 +1,8 @@
 package com.challenge.api.service.fcm;
 
 import com.challenge.api.service.fcm.request.FcmMessage;
+import com.challenge.api.service.fcm.request.TokenSaveServiceRequest;
+import com.challenge.domain.member.Member;
 import com.challenge.exception.ErrorCode;
 import com.challenge.exception.GlobalException;
 import com.google.firebase.messaging.ApnsConfig;
@@ -11,6 +13,7 @@ import com.google.firebase.messaging.Message;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -31,6 +34,13 @@ public class FcmService {
         }
 
         return "fcm 푸시 발송 성공";
+    }
+
+    @Transactional
+    public String saveToken(TokenSaveServiceRequest request, Member member) {
+        member.updateFcmToken(request.getToken());
+
+        return "fcm 토큰 저장 성공";
     }
 
     private ApnsConfig getApnsConfig(FcmMessage request) {

--- a/src/main/java/com/challenge/api/service/fcm/FcmService.java
+++ b/src/main/java/com/challenge/api/service/fcm/FcmService.java
@@ -1,0 +1,42 @@
+package com.challenge.api.service.fcm;
+
+import com.challenge.api.service.fcm.request.FcmMessage;
+import com.challenge.exception.ErrorCode;
+import com.challenge.exception.GlobalException;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.ApsAlert;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmService {
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    public String sendMessage(FcmMessage request) {
+        try {
+            Message message = request.buildMessage().setApnsConfig(getApnsConfig(request)).build();
+            log.info("Sending message: {}", message);
+            String send = firebaseMessaging.send(message);
+            log.info("Sent message: {}", send);
+        } catch (Exception exception) {
+            log.error(exception.getMessage(), exception);
+            throw new GlobalException(ErrorCode.FCM_SERVICE_UNAVAILABLE);
+        }
+
+        return "fcm 푸시 발송 성공";
+    }
+
+    private ApnsConfig getApnsConfig(FcmMessage request) {
+        ApsAlert alert = ApsAlert.builder().setTitle(request.getTitle()).setBody(request.getBody()).build();
+        Aps aps = Aps.builder().setAlert(alert).setSound("default").build();
+        return ApnsConfig.builder().setAps(aps).build();
+    }
+
+}

--- a/src/main/java/com/challenge/api/service/fcm/request/FcmMessage.java
+++ b/src/main/java/com/challenge/api/service/fcm/request/FcmMessage.java
@@ -1,0 +1,37 @@
+package com.challenge.api.service.fcm.request;
+
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FcmMessage {
+
+    String token;
+    String title;
+    String body;
+
+    public static FcmMessage of(String token, String title, String body) {
+        return FcmMessage.builder()
+                .token(token)
+                .title(title)
+                .body(body)
+                .build();
+    }
+
+    public Message.Builder buildMessage() {
+        return Message.builder()
+                .setToken(token)
+                .setNotification(toNotification());
+    }
+
+    public Notification toNotification() {
+        return Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build();
+    }
+
+}

--- a/src/main/java/com/challenge/api/service/fcm/request/TokenSaveServiceRequest.java
+++ b/src/main/java/com/challenge/api/service/fcm/request/TokenSaveServiceRequest.java
@@ -1,0 +1,18 @@
+package com.challenge.api.service.fcm.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenSaveServiceRequest {
+
+    String token;
+
+    @Builder
+    private TokenSaveServiceRequest(String token) {
+        this.token = token;
+    }
+
+}

--- a/src/main/java/com/challenge/config/FcmConfig.java
+++ b/src/main/java/com/challenge/config/FcmConfig.java
@@ -1,0 +1,49 @@
+package com.challenge.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+
+@Configuration
+public class FcmConfig {
+
+    private final ClassPathResource firebaseResource;
+    private final String projectId;
+
+    public FcmConfig(@Value("${fcm.file_path}") String firebaseFilePath,
+                     @Value("${fcm.project_id}") String projectId) {
+        this.firebaseResource = new ClassPathResource(firebaseFilePath);
+        this.projectId = projectId;
+    }
+
+    @PostConstruct
+    public void init() throws IOException {
+        FirebaseOptions option = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(firebaseResource.getInputStream()))
+                .setProjectId(projectId)
+                .build();
+
+        if (FirebaseApp.getApps().isEmpty()) {
+            FirebaseApp.initializeApp(option);
+        }
+    }
+
+    @Bean
+    FirebaseMessaging firebaseMessaging() {
+        return FirebaseMessaging.getInstance(firebaseApp());
+    }
+
+    @Bean
+    FirebaseApp firebaseApp() {
+        return FirebaseApp.getInstance();
+    }
+
+}

--- a/src/main/java/com/challenge/config/WebConfig.java
+++ b/src/main/java/com/challenge/config/WebConfig.java
@@ -18,7 +18,7 @@ public class WebConfig implements WebMvcConfigurer {
     private final AuthMemberArgumentResolver authMemberArgumentResolver;
     private final AuthInterceptor authInterceptor;
     private final List<String> excludeEndpoints = Arrays.asList("/api/v1/auth/**", "/api/v1/member/nickname/valid",
-            "/api/v1/fcm/send");
+            "/api/v1/fcm/send/**");
 
     // 인터셉터 설정
     @Override

--- a/src/main/java/com/challenge/config/WebConfig.java
+++ b/src/main/java/com/challenge/config/WebConfig.java
@@ -17,7 +17,8 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final AuthMemberArgumentResolver authMemberArgumentResolver;
     private final AuthInterceptor authInterceptor;
-    private final List<String> excludeEndpoints = Arrays.asList("/api/v1/auth/**", "/api/v1/member/nickname/valid");
+    private final List<String> excludeEndpoints = Arrays.asList("/api/v1/auth/**", "/api/v1/member/nickname/valid",
+            "/api/v1/fcm/send");
 
     // 인터셉터 설정
     @Override

--- a/src/main/java/com/challenge/domain/member/Member.java
+++ b/src/main/java/com/challenge/domain/member/Member.java
@@ -66,6 +66,9 @@ public class Member extends BaseDateTimeEntity {
     @Column(columnDefinition = "BOOLEAN DEFAULT false")
     private boolean isNotificationReceived = false;
 
+    @Column(length = 400)
+    private String fcmToken;
+
     @Column(columnDefinition = "BOOLEAN DEFAULT false")
     private boolean isDeleted = false;
 
@@ -134,6 +137,10 @@ public class Member extends BaseDateTimeEntity {
 
     public void updateNotificationReceived() {
         this.isNotificationReceived = !this.isNotificationReceived;
+    }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
     }
 
 }

--- a/src/main/java/com/challenge/domain/notification/Notification.java
+++ b/src/main/java/com/challenge/domain/notification/Notification.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,13 +33,27 @@ public class Notification extends BaseDateTimeEntity {
     @Column(nullable = false, length = 500)
     private String content;
 
-    @Column(nullable = false, columnDefinition = "boolean default false")
-    private boolean isSend;
-
     private LocalDateTime sendAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    public static Notification of(String title, String content, LocalDateTime sendAt, Member member) {
+        return Notification.builder()
+                .title(title)
+                .content(content)
+                .sendAt(sendAt)
+                .member(member)
+                .build();
+    }
+
+    @Builder
+    private Notification(String title, String content, LocalDateTime sendAt, Member member) {
+        this.title = title;
+        this.content = content;
+        this.sendAt = sendAt;
+        this.member = member;
+    }
 
 }

--- a/src/main/java/com/challenge/domain/notification/NotificationRepository.java
+++ b/src/main/java/com/challenge/domain/notification/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.challenge.domain.notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/com/challenge/exception/ErrorCode.java
+++ b/src/main/java/com/challenge/exception/ErrorCode.java
@@ -84,7 +84,8 @@ public enum ErrorCode {
      */
     JOB_NOT_FOUND(NOT_FOUND, "ERROR_4001", "직무 정보를 찾을 수 없습니다. 관리자에게 문의 바랍니다."),
     S3_UPLOAD_ERROR(INTERNAL_SERVER_ERROR, "ERROR_4002", "이미지 업로드에 실패했습니다. 관리자에게 문의 바랍니다."),
-    FCM_SERVICE_UNAVAILABLE(INTERNAL_SERVER_ERROR, "ERROR_4003", "FCM 서버 요청에 실패했습니다. 관리자에게 문의 바랍니다.");
+    FCM_SERVICE_UNAVAILABLE(INTERNAL_SERVER_ERROR, "ERROR_4003", "FCM 서버 요청에 실패했습니다. 관리자에게 문의 바랍니다."),
+    FCM_TOKEN_NOT_FOUND(NOT_FOUND, "ERROR_4004", "해당 회원의 FCM 토큰을 찾을 수 없습니다. 관리자에게 문의 바랍니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/challenge/exception/ErrorCode.java
+++ b/src/main/java/com/challenge/exception/ErrorCode.java
@@ -83,8 +83,9 @@ public enum ErrorCode {
      * 기타 에러
      */
     JOB_NOT_FOUND(NOT_FOUND, "ERROR_4001", "직무 정보를 찾을 수 없습니다. 관리자에게 문의 바랍니다."),
-    S3_UPLOAD_ERROR(INTERNAL_SERVER_ERROR, "ERROR_4002", "이미지 업로드에 실패했습니다. 관리자에게 문의 바랍니다.");
-    
+    S3_UPLOAD_ERROR(INTERNAL_SERVER_ERROR, "ERROR_4002", "이미지 업로드에 실패했습니다. 관리자에게 문의 바랍니다."),
+    FCM_SERVICE_UNAVAILABLE(INTERNAL_SERVER_ERROR, "ERROR_4003", "FCM 서버 요청에 실패했습니다. 관리자에게 문의 바랍니다.");
+
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,3 +92,7 @@ cloud:
       static: ${S3_REGION}
     stack:
       auto: false
+
+fcm:
+  file_path: firebase/firebase.json
+  project_id: ${FIREBASE_PROJECT_ID}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
FCM 알림 전송 구현 및 테스트 API 구현

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- member 엔티티에 fcmToken 필드 추가
- notification 엔티티에 isSend 필드 제거
- FCM 관련 설정 파일 추가
- FCM 알림 전송 메소드 구현
- FCM 토큰 등록 API 구현
- FCM 토큰 삭제 API 구현
- 알림 발송 테스트용 API 구현

## ⏳ 작업 내용
- [x] FCM 알림 전송 기능 구현
- [x] 알림 전송 테스트를 위한 API 구현
- [x] FCM 토큰 등록 API 구현
- [x] FCM 토큰 삭제 API 구현
- [x] memberId로 알림 전송 API 구현 (알림 전송 테스트용)

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
firebase.json 파일 추가 및 FIREBASE_PROJECT_ID 환경변수 설정 추가가 필요합니다.
(노션 백엔드>프로젝트 정보 페이지 참고)
