### PR TITLE
[Fix/93] 직무, 연차 정보 선택 안함 옵션 가능하도록 수정

### DIFF
--- a/src/main/java/com/challenge/api/controller/auth/request/KakaoSigninRequest.java
+++ b/src/main/java/com/challenge/api/controller/auth/request/KakaoSigninRequest.java
@@ -31,12 +31,12 @@ public class KakaoSigninRequest {
     private Gender gender;
 
     @NotNull(message = "jobId는 필수 입력값입니다.")
-    @Min(value = 1, message = "jobId는 1 이상의 값이어야 합니다.")
+    @Min(value = 0, message = "jobId는 0 이상의 값이어야 합니다.")
     @Max(value = 20, message = "jobId는 20 이하의 값이어야 합니다.")
     private Long jobId;
 
     @NotNull(message = "yearId는 필수 입력값입니다.")
-    @Min(value = 1, message = "yearId는 1 이상의 값이어야 합니다.")
+    @Min(value = 0, message = "yearId는 0 이상의 값이어야 합니다.")
     @Max(value = 4, message = "yearId는 4 이하의 값이어야 합니다.")
     private int yearId;
 
@@ -53,7 +53,7 @@ public class KakaoSigninRequest {
 
     @Builder
     private KakaoSigninRequest(String accessToken, String nickname, String birth, Gender gender, Long jobId,
-            int yearId) {
+                               int yearId) {
         this.accessToken = accessToken;
         this.nickname = nickname;
         this.birth = birth;

--- a/src/main/java/com/challenge/api/controller/member/request/UpdateJobRequest.java
+++ b/src/main/java/com/challenge/api/controller/member/request/UpdateJobRequest.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class UpdateJobRequest {
 
     @NotNull(message = "jobId는 필수 입력값입니다.")
-    @Min(value = 1, message = "jobId는 1 이상의 값이어야 합니다.")
+    @Min(value = 0, message = "jobId는 0 이상의 값이어야 합니다.")
     @Max(value = 20, message = "jobId는 20 이하의 값이어야 합니다.")
     private Long jobId;
 

--- a/src/main/java/com/challenge/api/controller/member/request/UpdateJobYearRequest.java
+++ b/src/main/java/com/challenge/api/controller/member/request/UpdateJobYearRequest.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class UpdateJobYearRequest {
 
     @NotNull(message = "yearId는 필수 입력값입니다.")
-    @Min(value = 1, message = "yearId는 1 이상의 값이어야 합니다.")
+    @Min(value = 0, message = "yearId는 0 이상의 값이어야 합니다.")
     @Max(value = 4, message = "yearId는 4 이하의 값이어야 합니다.")
     private int yearId;
 

--- a/src/main/java/com/challenge/api/service/auth/AuthService.java
+++ b/src/main/java/com/challenge/api/service/auth/AuthService.java
@@ -73,11 +73,21 @@ public class AuthService {
         authValidator.validateUniqueNickname(request.getNickname());
 
         // 직무 데이터 설정
-        Job job = jobRepository.findById(request.getJobId())
-                .orElseThrow(() -> new GlobalException(ErrorCode.JOB_NOT_FOUND));
+        Job job;
+        if (request.getJobId() == 0) {
+            job = null;
+        } else {
+            job = jobRepository.findById(request.getJobId())
+                    .orElseThrow(() -> new GlobalException(ErrorCode.JOB_NOT_FOUND));
+        }
 
         // 연차 enum 데이터 설정
-        JobYear jobYear = JobYear.of(request.getYearId());
+        JobYear jobYear;
+        if (request.getYearId() == 0) {
+            jobYear = null;
+        } else {
+            jobYear = JobYear.of(request.getYearId());
+        }
 
         // member 엔티티 생성 및 저장
         Member member = Member.create(userInfo.getSocialId(), userInfo.getEmail(), request.getNickname(),

--- a/src/main/java/com/challenge/api/service/member/MemberService.java
+++ b/src/main/java/com/challenge/api/service/member/MemberService.java
@@ -127,11 +127,15 @@ public class MemberService {
      */
     @Transactional
     public String updateJob(Member member, UpdateJobServiceRequest request) {
-        // 직무 데이터 조회
-        Job job = jobRepository.findById(request.getJobId())
-                .orElseThrow(() -> new GlobalException(ErrorCode.JOB_NOT_FOUND));
+        if (request.getJobId() == 0) {
+            member.updateJob(null);
+        } else {
+            // 직무 데이터 조회
+            Job job = jobRepository.findById(request.getJobId())
+                    .orElseThrow(() -> new GlobalException(ErrorCode.JOB_NOT_FOUND));
 
-        member.updateJob(job);
+            member.updateJob(job);
+        }
 
         return "직업 수정 성공";
     }
@@ -145,9 +149,12 @@ public class MemberService {
      */
     @Transactional
     public String updateJobYear(Member member, UpdateJobYearServiceRequest request) {
-        JobYear jobYear = JobYear.of(request.getYearId());
-
-        member.updateJobYear(jobYear);
+        if (request.getYearId() == 0) {
+            member.updateJobYear(null);
+        } else {
+            JobYear jobYear = JobYear.of(request.getYearId());
+            member.updateJobYear(jobYear);
+        }
 
         return "연차 수정 성공";
     }

--- a/src/main/java/com/challenge/api/service/member/response/MemberInfoResponse.java
+++ b/src/main/java/com/challenge/api/service/member/response/MemberInfoResponse.java
@@ -12,12 +12,13 @@ public class MemberInfoResponse {
     private final String nickname;
     private final String birth;
     private final Gender gender;
-    private final long jobId;
+    private final Long jobId;
     private final String job;
-    private final int jobYearId;
+    private final Integer jobYearId;
 
     @Builder
-    private MemberInfoResponse(String nickname, String birth, Gender gender, long jobId, String job, int jobYearId) {
+    private MemberInfoResponse(String nickname, String birth, Gender gender, Long jobId, String job,
+                               Integer jobYearId) {
         this.nickname = nickname;
         this.birth = birth;
         this.gender = gender;
@@ -27,13 +28,17 @@ public class MemberInfoResponse {
     }
 
     public static MemberInfoResponse of(Member member) {
+        Long jobId = member.getJob() == null ? null : member.getJob().getId();
+        String job = member.getJob() == null ? null : member.getJob().getDescription();
+        Integer jobYearId = member.getJobYear() == null ? null : member.getJobYear().getId();
+
         return MemberInfoResponse.builder()
                 .nickname(member.getNickname())
                 .birth(DateUtils.toDayString(member.getBirth()))
                 .gender(member.getGender())
-                .jobId(member.getJob().getId())
-                .job(member.getJob().getDescription())
-                .jobYearId(member.getJobYear().getId())
+                .jobId(jobId)
+                .job(job)
+                .jobYearId(jobYearId)
                 .build();
     }
 

--- a/src/main/java/com/challenge/domain/member/Member.java
+++ b/src/main/java/com/challenge/domain/member/Member.java
@@ -53,7 +53,7 @@ public class Member extends BaseDateTimeEntity {
     private Gender gender;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(10)", nullable = false)
+    @Column(columnDefinition = "VARCHAR(10)")
     private JobYear jobYear;
 
     @Column(length = 1000)

--- a/src/test/java/com/challenge/api/controller/auth/AuthControllerTest.java
+++ b/src/test/java/com/challenge/api/controller/auth/AuthControllerTest.java
@@ -293,7 +293,7 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
         }
 
-        @DisplayName("카카오 회원가입 실패: jobId가 1 미만인 경우 에러 응답을 반환한다.")
+        @DisplayName("카카오 회원가입 실패: jobId가 0 미만인 경우 에러 응답을 반환한다.")
         @Test
         void kakaoSigninFailedWhenJobIdIsLessThanMin() throws Exception {
             // given
@@ -302,7 +302,7 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .nickname(MOCK_NICKNAME)
                     .birth(MOCK_BIRTH)
                     .gender(MOCK_GENDER)
-                    .jobId(0L)
+                    .jobId(-1L)
                     .yearId(MOCK_JOBYEAR.getId())
                     .build();
 
@@ -311,7 +311,7 @@ public class AuthControllerTest extends ControllerTestSupport {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().is(400))
-                    .andExpect(jsonPath("$.message").value("jobId는 1 이상의 값이어야 합니다."))
+                    .andExpect(jsonPath("$.message").value("jobId는 0 이상의 값이어야 합니다."))
                     .andExpect(jsonPath("$.code").value("VALID_ERROR"))
                     .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
         }
@@ -339,7 +339,7 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
         }
 
-        @DisplayName("카카오 회원가입 실패: yearId가 1 미만인 경우 에러 응답을 반환한다.")
+        @DisplayName("카카오 회원가입 실패: yearId가 0 미만인 경우 에러 응답을 반환한다.")
         @Test
         void kakaoSigninFailedWhenYearIdIsLessThanMin() throws Exception {
             // given
@@ -349,7 +349,7 @@ public class AuthControllerTest extends ControllerTestSupport {
                     .birth(MOCK_BIRTH)
                     .gender(MOCK_GENDER)
                     .jobId(MOCK_JOB.getId())
-                    .yearId(0)
+                    .yearId(-1)
                     .build();
 
             // when // then
@@ -357,7 +357,7 @@ public class AuthControllerTest extends ControllerTestSupport {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().is(400))
-                    .andExpect(jsonPath("$.message").value("yearId는 1 이상의 값이어야 합니다."))
+                    .andExpect(jsonPath("$.message").value("yearId는 0 이상의 값이어야 합니다."))
                     .andExpect(jsonPath("$.code").value("VALID_ERROR"))
                     .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"));
         }

--- a/src/test/java/com/challenge/api/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/challenge/api/controller/member/MemberControllerTest.java
@@ -322,12 +322,12 @@ class MemberControllerTest extends ControllerTestSupport {
                     .andExpect(jsonPath("$.url").value("/api/v1/member/job"));
         }
 
-        @DisplayName("직무 수정 실패: jobId가 1 미만인 경우 에러 응답을 반환한다.")
+        @DisplayName("직무 수정 실패: jobId가 0 미만인 경우 에러 응답을 반환한다.")
         @Test
         void updateJobFailedWhenJobIdIsLessThanMin() throws Exception {
             // given
             UpdateJobRequest request = UpdateJobRequest.builder()
-                    .jobId(0L)
+                    .jobId(-1L)
                     .build();
 
             // when // then
@@ -335,7 +335,7 @@ class MemberControllerTest extends ControllerTestSupport {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().is(400))
-                    .andExpect(jsonPath("$.message").value("jobId는 1 이상의 값이어야 합니다."))
+                    .andExpect(jsonPath("$.message").value("jobId는 0 이상의 값이어야 합니다."))
                     .andExpect(jsonPath("$.code").value("VALID_ERROR"))
                     .andExpect(jsonPath("$.url").value("/api/v1/member/job"));
         }
@@ -390,12 +390,12 @@ class MemberControllerTest extends ControllerTestSupport {
                     .andExpect(jsonPath("$.data").value(updateJobYearResponse));
         }
 
-        @DisplayName("연차 수정 실패: yearId가 1 미만인 경우 에러 응답을 반환한다.")
+        @DisplayName("연차 수정 실패: yearId가 0 미만인 경우 에러 응답을 반환한다.")
         @Test
         void updateJobYearFailedWhenIdIsLessThanMin() throws Exception {
             // given
             UpdateJobYearRequest request = UpdateJobYearRequest.builder()
-                    .yearId(0)
+                    .yearId(-1)
                     .build();
 
             // when // then
@@ -403,7 +403,7 @@ class MemberControllerTest extends ControllerTestSupport {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().is(400))
-                    .andExpect(jsonPath("$.message").value("yearId는 1 이상의 값이어야 합니다."))
+                    .andExpect(jsonPath("$.message").value("yearId는 0 이상의 값이어야 합니다."))
                     .andExpect(jsonPath("$.code").value("VALID_ERROR"))
                     .andExpect(jsonPath("$.url").value("/api/v1/member/jobyear"));
         }

--- a/src/test/java/com/challenge/docs/AuthControllerDocsTest.java
+++ b/src/test/java/com/challenge/docs/AuthControllerDocsTest.java
@@ -355,7 +355,7 @@ class AuthControllerDocsTest extends RestDocsSupport {
                     ));
         }
 
-        @DisplayName("카카오 회원가입 실패: jobId가 1 미만인 경우")
+        @DisplayName("카카오 회원가입 실패: jobId가 0 미만인 경우")
         @Test
         void kakaoSigninFailJobIdLessThan() throws Exception {
             // given
@@ -364,7 +364,7 @@ class AuthControllerDocsTest extends RestDocsSupport {
                     .nickname(MOCK_NICKNAME)
                     .birth(MOCK_BIRTH)
                     .gender(MOCK_GENDER)
-                    .jobId(0L)
+                    .jobId(-1L)
                     .yearId(MOCK_JOBYEAR.getId())
                     .build();
 
@@ -373,7 +373,7 @@ class AuthControllerDocsTest extends RestDocsSupport {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().is(400))
-                    .andExpect(jsonPath("$.message").value("jobId는 1 이상의 값이어야 합니다."))
+                    .andExpect(jsonPath("$.message").value("jobId는 0 이상의 값이어야 합니다."))
                     .andExpect(jsonPath("$.code").value("VALID_ERROR"))
                     .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"))
                     .andDo(restDocs.document(
@@ -409,7 +409,7 @@ class AuthControllerDocsTest extends RestDocsSupport {
                     ));
         }
 
-        @DisplayName("카카오 회원가입 실패: yearId가 1 미만인 경우")
+        @DisplayName("카카오 회원가입 실패: yearId가 0 미만인 경우")
         @Test
         void kakaoSigninFailYearIdLessThan() throws Exception {
             // given
@@ -419,7 +419,7 @@ class AuthControllerDocsTest extends RestDocsSupport {
                     .birth(MOCK_BIRTH)
                     .gender(MOCK_GENDER)
                     .jobId(MOCK_JOB.getId())
-                    .yearId(0)
+                    .yearId(-1)
                     .build();
 
             // when // then
@@ -427,7 +427,7 @@ class AuthControllerDocsTest extends RestDocsSupport {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().is(400))
-                    .andExpect(jsonPath("$.message").value("yearId는 1 이상의 값이어야 합니다."))
+                    .andExpect(jsonPath("$.message").value("yearId는 0 이상의 값이어야 합니다."))
                     .andExpect(jsonPath("$.code").value("VALID_ERROR"))
                     .andExpect(jsonPath("$.url").value("/api/v1/auth/signin/kakao"))
                     .andDo(restDocs.document(

--- a/src/test/java/com/challenge/docs/MemberControllerDocsTest.java
+++ b/src/test/java/com/challenge/docs/MemberControllerDocsTest.java
@@ -470,12 +470,12 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                     ));
         }
 
-        @DisplayName("직무 수정 실패: jobId가 1 미만인 경우 에러 응답을 반환한다.")
+        @DisplayName("직무 수정 실패: jobId가 0 미만인 경우 에러 응답을 반환한다.")
         @Test
         void updateJobFailIdLessThan() throws Exception {
             // given
             UpdateJobRequest request = UpdateJobRequest.builder()
-                    .jobId(0L)
+                    .jobId(-1L)
                     .build();
 
             // when // then
@@ -483,7 +483,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().is(400))
-                    .andExpect(jsonPath("$.message").value("jobId는 1 이상의 값이어야 합니다."))
+                    .andExpect(jsonPath("$.message").value("jobId는 0 이상의 값이어야 합니다."))
                     .andExpect(jsonPath("$.code").value("VALID_ERROR"))
                     .andExpect(jsonPath("$.url").value("/api/v1/member/job"))
                     .andDo(restDocs.document(
@@ -569,12 +569,12 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                     ));
         }
 
-        @DisplayName("연차 수정 실패: yearId가 1 미만인 경우 에러 응답을 반환한다.")
+        @DisplayName("연차 수정 실패: yearId가 0 미만인 경우 에러 응답을 반환한다.")
         @Test
         void updateJobYearFailIdLessThan() throws Exception {
             // given
             UpdateJobYearRequest request = UpdateJobYearRequest.builder()
-                    .yearId(0)
+                    .yearId(-1)
                     .build();
 
             // when // then
@@ -582,7 +582,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().is(400))
-                    .andExpect(jsonPath("$.message").value("yearId는 1 이상의 값이어야 합니다."))
+                    .andExpect(jsonPath("$.message").value("yearId는 0 이상의 값이어야 합니다."))
                     .andExpect(jsonPath("$.code").value("VALID_ERROR"))
                     .andExpect(jsonPath("$.url").value("/api/v1/member/jobyear"))
                     .andDo(restDocs.document(


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
회원 가입 및 회원 정보 수정 시 직무, 연차 정보 선택 안함 옵션이 가능하도록 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- jobId, jobYearId 요청 값 0도 가능하도록 변경
- 관련 테스트 케이스 수정

## ⏳ 작업 내용
- [x] jobId, jobYearId 요청 값 0도 가능하도록 변경
- [x] 관련 테스트 케이스 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
